### PR TITLE
feat(shopping): implement screen wake lock (GRO-47)

### DIFF
--- a/src/features/lists/components/ListEditor.tsx
+++ b/src/features/lists/components/ListEditor.tsx
@@ -28,6 +28,7 @@ import { completeList } from "@/actions/list"
 import { useRouter } from "next/navigation"
 import { MoreHorizontal, Pencil, Trash2, ShoppingCart, CheckCheck, X } from "lucide-react"
 import { ListItemRow } from "./ListItemRow"
+import { useScreenWakeLock } from "@/hooks/use-screen-wake-lock"
 import { QuantityStepper } from "./QuantityStepper"
 import {
     DropdownMenu,
@@ -133,6 +134,13 @@ export function ListEditor({ list }: ListEditorProps) {
     // Edit Item State
     const [editingItem, setEditingItem] = useState<Item | null>(null)
     const [isEditOpen, setIsEditOpen] = useState(false)
+
+    // Screen Wake Lock for Shopping Mode
+    const isReadOnly = list.status === "COMPLETED"
+    const isPlanningMode = list.status === "PLANNING"
+    const isShoppingMode = list.status === "SHOPPING"
+
+    useScreenWakeLock(isShoppingMode)
 
     const handleAddItem = async (e?: React.FormEvent) => {
         e?.preventDefault()
@@ -418,9 +426,7 @@ export function ListEditor({ list }: ListEditorProps) {
             unit: i.unit
         }))
 
-    const isReadOnly = list.status === "COMPLETED"
-    const isPlanningMode = list.status === "PLANNING"
-    const isShoppingMode = list.status === "SHOPPING"
+
 
     return (
         <div className="space-y-8 pb-32">

--- a/src/hooks/use-screen-wake-lock.ts
+++ b/src/hooks/use-screen-wake-lock.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+
+export function useScreenWakeLock(enabled: boolean = true) {
+    const [isSupported, setIsSupported] = useState(false)
+    const [isLocked, setIsLocked] = useState(false)
+    const [wakeLock, setWakeLock] = useState<WakeLockSentinel | null>(null)
+
+    useEffect(() => {
+        setIsSupported("wakeLock" in navigator)
+    }, [])
+
+    const requestLock = useCallback(async () => {
+        if (!("wakeLock" in navigator)) return
+
+        try {
+            const lock = await navigator.wakeLock.request("screen")
+            setWakeLock(lock)
+            setIsLocked(true)
+
+            lock.addEventListener("release", () => {
+                setIsLocked(false)
+                setWakeLock(null)
+            })
+            console.log("Wake Lock acquired")
+        } catch (err: any) {
+            console.error(`Wake Lock request failed: ${err.name}, ${err.message}`)
+            // Don't toast on error, might be noisy if frequent
+        }
+    }, [])
+
+    const releaseLock = useCallback(async () => {
+        if (wakeLock) {
+            try {
+                await wakeLock.release()
+                setWakeLock(null)
+            } catch (err: any) {
+                console.error(`Wake Lock release failed: ${err.name}, ${err.message}`)
+            }
+        }
+    }, [wakeLock])
+
+    useEffect(() => {
+        // If enabled and supported, try to request
+        if (enabled && isSupported) {
+            requestLock()
+        }
+
+        // Cleanup on disable/unmount
+        return () => {
+            if (wakeLock) releaseLock()
+        }
+    }, [enabled, isSupported, requestLock, releaseLock, wakeLock])
+
+    // Re-acquire lock when page becomes visible again (system might release it on background)
+    useEffect(() => {
+        const handleVisibilityChange = async () => {
+            if (document.visibilityState === "visible" && enabled && isSupported && !isLocked) {
+                await requestLock()
+            }
+        }
+
+        document.addEventListener("visibilitychange", handleVisibilityChange)
+        return () => {
+            document.removeEventListener("visibilitychange", handleVisibilityChange)
+        }
+    }, [enabled, isSupported, isLocked, requestLock])
+
+    return { isSupported, isLocked, release: releaseLock, request: requestLock }
+}

--- a/src/hooks/use-screen-wake-lock.ts
+++ b/src/hooks/use-screen-wake-lock.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import { toast } from "sonner"
+
 
 export function useScreenWakeLock(enabled: boolean = true) {
     const [isSupported, setIsSupported] = useState(false)
@@ -44,7 +44,7 @@ export function useScreenWakeLock(enabled: boolean = true) {
 
     useEffect(() => {
         // If enabled and supported, try to request
-        if (enabled && isSupported) {
+        if (enabled && isSupported && !wakeLock) {
             requestLock()
         }
 


### PR DESCRIPTION
- Added useScreenWakeLock hook
- Integrated wake lock into ListEditor for SHOPPING mode
- Fixed variable shadowing in ListEditor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device screen now stays awake automatically when actively using a list in Shopping mode to prevent interruptions.

* **Bug Fixes / Improvements**
  * Wake-lock behavior is now applied only in Shopping mode and is more reliable (reduces duplicate/incorrect mode handling).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->