### PR TITLE
feat: derive household permissions from local RxDB state (#8)

### DIFF
--- a/apps/web/src/features/households/components/Invitations/InvitationManager.tsx
+++ b/apps/web/src/features/households/components/Invitations/InvitationManager.tsx
@@ -210,7 +210,7 @@ export function InvitationManager({ userId, households, invitationTimeoutMinutes
                 <h3 className="text-sm font-medium text-muted-foreground">Your Households</h3>
                 {households.map((household) => {
                     const perms = deriveHouseholdPermissions(
-                        { ownerId: household.ownerId ?? '', memberCount: household._count.users },
+                        { ownerId: household.ownerId, memberCount: household._count.users },
                         userId,
                     )
 

--- a/apps/web/src/features/households/components/Invitations/InvitationManager.tsx
+++ b/apps/web/src/features/households/components/Invitations/InvitationManager.tsx
@@ -32,6 +32,9 @@ import {
     useDeleteHousehold,
 } from "../../hooks/useHouseholds"
 import { useLeaveHousehold } from "../../hooks/useInvitations"
+import {
+    deriveHouseholdPermissions
+} from "../../hooks/useHouseholdPermissions"
 
 interface InvitationManagerProps {
     userId: string
@@ -206,8 +209,10 @@ export function InvitationManager({ userId, households, invitationTimeoutMinutes
             <div className="space-y-4">
                 <h3 className="text-sm font-medium text-muted-foreground">Your Households</h3>
                 {households.map((household) => {
-                    const isOwner = household.ownerId === userId
-                    const memberCount = household._count.users
+                    const perms = deriveHouseholdPermissions(
+                        { ownerId: household.ownerId ?? '', memberCount: household._count.users },
+                        userId,
+                    )
 
                     return (
                         <Card key={household.id}>
@@ -216,18 +221,18 @@ export function InvitationManager({ userId, households, invitationTimeoutMinutes
                                     <div className="space-y-1">
                                         <div className="flex items-center gap-2">
                                             <CardTitle className="text-base">{household.name}</CardTitle>
-                                            {isOwner ? (
+                                            {perms.isOwner ? (
                                                 <Badge variant="default" className="text-[10px] px-1 py-0 h-5"><Shield className="w-3 h-3 mr-1" /> Owner</Badge>
                                             ) : (
                                                 <Badge variant="secondary" className="text-[10px] px-1 py-0 h-5"><User className="w-3 h-3 mr-1" /> Member</Badge>
                                             )}
                                         </div>
                                         <CardDescription className="text-xs">
-                                            ID: {household.id} &bull; {memberCount} member{memberCount !== 1 ? 's' : ''}
+                                            ID: {household.id} &bull; {household._count.users} member{household._count.users !== 1 ? 's' : ''}
                                         </CardDescription>
                                     </div>
                                     <div className="flex gap-2">
-                                        {isOwner && (
+                                        {perms.isOwner && (
                                             <Dialog open={editingHousehold?.id === household.id} onOpenChange={(open) => {
                                                 if (open) {
                                                     setEditingHousehold(household)
@@ -311,18 +316,7 @@ export function InvitationManager({ userId, households, invitationTimeoutMinutes
                                         </Dialog>
 
                                         {/* Leave/Delete Button */}
-                                        {isOwner ? (
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                                                disabled={memberCount > 1}
-                                                onClick={() => setHouseholdToDelete({ id: household.id, name: household.name, memberCount })}
-                                                title={memberCount > 1 ? "Cannot delete household with other members" : "Delete Household"}
-                                            >
-                                                <Trash2 className="h-4 w-4" />
-                                            </Button>
-                                        ) : (
+                                        {perms.canLeave ? (
                                             <Button
                                                 variant="ghost"
                                                 size="icon"
@@ -331,6 +325,27 @@ export function InvitationManager({ userId, households, invitationTimeoutMinutes
                                                 title="Leave Household"
                                             >
                                                 <LogOut className="h-4 w-4" />
+                                            </Button>
+                                        ) : perms.canDelete ? (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                                onClick={() => setHouseholdToDelete({ id: household.id, name: household.name, memberCount: household._count.users })}
+                                                title="Delete Household"
+                                            >
+                                                <Trash2 className="h-4 w-4" />
+                                            </Button>
+                                        ) : (
+                                            /* Owner with other members — can't leave or delete, blocked on #9 */
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-8 w-8 text-muted-foreground"
+                                                disabled
+                                                title="Transfer ownership before leaving or deleting"
+                                            >
+                                                <Trash2 className="h-4 w-4" />
                                             </Button>
                                         )}
                                     </div>

--- a/apps/web/src/features/households/hooks/__tests__/useHouseholdPermissions.test.ts
+++ b/apps/web/src/features/households/hooks/__tests__/useHouseholdPermissions.test.ts
@@ -60,14 +60,25 @@ describe('deriveHouseholdPermissions', () => {
     })
   })
 
-  describe('ownerId null/empty fallback', () => {
-    it('treats empty ownerId as non-owner', () => {
+  describe('ownerId null/empty — unknown owner', () => {
+    it('denies destructive actions when ownerId is null', () => {
+      const perms = deriveHouseholdPermissions(
+        { ownerId: null, memberCount: 1 },
+        userId,
+      )
+      expect(perms.isOwner).toBe(false)
+      expect(perms.canLeave).toBe(false)
+      expect(perms.canDelete).toBe(false)
+    })
+
+    it('denies destructive actions when ownerId is empty string', () => {
       const perms = deriveHouseholdPermissions(
         { ownerId: '', memberCount: 1 },
         userId,
       )
       expect(perms.isOwner).toBe(false)
-      expect(perms.canLeave).toBe(true)
+      expect(perms.canLeave).toBe(false)
+      expect(perms.canDelete).toBe(false)
     })
   })
 })

--- a/apps/web/src/features/households/hooks/__tests__/useHouseholdPermissions.test.ts
+++ b/apps/web/src/features/households/hooks/__tests__/useHouseholdPermissions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { deriveHouseholdPermissions, type HouseholdForPermissions } from '../useHouseholdPermissions'
+
+const userId = 'user-1'
+
+function hh(overrides: Partial<HouseholdForPermissions> = {}): HouseholdForPermissions {
+  return { ownerId: 'user-1', memberCount: 1, ...overrides }
+}
+
+describe('deriveHouseholdPermissions', () => {
+  describe('owner + solo member', () => {
+    const perms = deriveHouseholdPermissions(hh(), userId)
+
+    it('isOwner is true', () => { expect(perms.isOwner).toBe(true) })
+    it('isOnlyMember is true', () => { expect(perms.isOnlyMember).toBe(true) })
+    it('canLeave is false (owner cannot leave)', () => { expect(perms.canLeave).toBe(false) })
+    it('canDelete is true', () => { expect(perms.canDelete).toBe(true) })
+  })
+
+  describe('owner + multiple members', () => {
+    const perms = deriveHouseholdPermissions(hh({ memberCount: 3 }), userId)
+
+    it('isOwner is true', () => { expect(perms.isOwner).toBe(true) })
+    it('isOnlyMember is false', () => { expect(perms.isOnlyMember).toBe(false) })
+    it('canLeave is false (owner cannot leave)', () => { expect(perms.canLeave).toBe(false) })
+    it('canDelete is false (has other members)', () => { expect(perms.canDelete).toBe(false) })
+  })
+
+  describe('non-owner member', () => {
+    const perms = deriveHouseholdPermissions(
+      hh({ ownerId: 'user-2', memberCount: 2 }),
+      userId,
+    )
+
+    it('isOwner is false', () => { expect(perms.isOwner).toBe(false) })
+    it('isOnlyMember is false', () => { expect(perms.isOnlyMember).toBe(false) })
+    it('canLeave is true (non-owner can leave)', () => { expect(perms.canLeave).toBe(true) })
+    it('canDelete is false (non-owner cannot delete)', () => { expect(perms.canDelete).toBe(false) })
+  })
+
+  describe('non-owner solo member (only member is not the owner)', () => {
+    const perms = deriveHouseholdPermissions(
+      hh({ ownerId: 'user-2', memberCount: 1 }),
+      userId,
+    )
+
+    it('isOwner is false', () => { expect(perms.isOwner).toBe(false) })
+    it('isOnlyMember is true (only 1 member total)', () => { expect(perms.isOnlyMember).toBe(true) })
+    it('canLeave is true', () => { expect(perms.canLeave).toBe(true) })
+    it('canDelete is false (not the owner)', () => { expect(perms.canDelete).toBe(false) })
+  })
+
+  describe('non-owner + single member canLeave is true', () => {
+    it('non-owner can always leave', () => {
+      const perms = deriveHouseholdPermissions(
+        { ownerId: 'other', memberCount: 1 },
+        userId,
+      )
+      expect(perms.canLeave).toBe(true)
+    })
+  })
+
+  describe('ownerId null/empty fallback', () => {
+    it('treats empty ownerId as non-owner', () => {
+      const perms = deriveHouseholdPermissions(
+        { ownerId: '', memberCount: 1 },
+        userId,
+      )
+      expect(perms.isOwner).toBe(false)
+      expect(perms.canLeave).toBe(true)
+    })
+  })
+})

--- a/apps/web/src/features/households/hooks/useHouseholdPermissions.ts
+++ b/apps/web/src/features/households/hooks/useHouseholdPermissions.ts
@@ -1,0 +1,36 @@
+/**
+ * Synchronous derivation of household permission flags from RxDB state.
+ *
+ * Permissions are derived from local RxDB household documents (ownerId, memberCount)
+ * and the current user ID. No async fetch — no loading state.
+ *
+ * The backend independently validates the same rules at the API boundary.
+ */
+export interface HouseholdPermissions {
+  isOwner: boolean
+  isOnlyMember: boolean
+  canLeave: boolean
+  canDelete: boolean
+}
+
+export interface HouseholdForPermissions {
+  ownerId: string
+  memberCount: number
+}
+
+export function deriveHouseholdPermissions(
+  household: HouseholdForPermissions,
+  userId: string,
+): HouseholdPermissions {
+  const isOwner = household.ownerId === userId
+  const isOnlyMember = household.memberCount <= 1
+
+  return {
+    isOwner,
+    isOnlyMember,
+    // Non-owners can always leave
+    canLeave: !isOwner,
+    // Only owner of solo-member household can delete
+    canDelete: isOwner && isOnlyMember,
+  }
+}

--- a/apps/web/src/features/households/hooks/useHouseholdPermissions.ts
+++ b/apps/web/src/features/households/hooks/useHouseholdPermissions.ts
@@ -14,7 +14,7 @@ export interface HouseholdPermissions {
 }
 
 export interface HouseholdForPermissions {
-  ownerId: string
+  ownerId: string | null
   memberCount: number
 }
 
@@ -22,15 +22,17 @@ export function deriveHouseholdPermissions(
   household: HouseholdForPermissions,
   userId: string,
 ): HouseholdPermissions {
-  const isOwner = household.ownerId === userId
+  // When ownerId is missing from local state, conservatively treat as
+  // unknown-owner: deny destructive actions until ownership is resolved.
+  const ownerKnown = household.ownerId != null && household.ownerId !== ''
+  const isOwner = ownerKnown && household.ownerId === userId
   const isOnlyMember = household.memberCount <= 1
 
   return {
     isOwner,
     isOnlyMember,
-    // Non-owners can always leave
-    canLeave: !isOwner,
-    // Only owner of solo-member household can delete
+    // Only allow leave/delete when ownership is definitively known
+    canLeave: ownerKnown && !isOwner,
     canDelete: isOwner && isOnlyMember,
   }
 }

--- a/planning/tickets/FEATURE-INTAKE.md
+++ b/planning/tickets/FEATURE-INTAKE.md
@@ -281,3 +281,11 @@ lost in chat history without forcing premature planning.
 - **Raw request:** A calendar view showing when shopping trips happened — dots or markers on dates, tap to see trip summary. Natural companion to the trip detail view.
 - **Context / notes:** Low implementation cost if trip history exists — just a calendar renderer with aggregated trip dates. Could show trip count per day, total spend per day (if price tracking exists). Complements filter modes (#23) by giving a time-based lens on shopping patterns.
 - **Links:** #26
+
+### 2026-06-17 — Cross-section drag-and-drop for item reassignment
+
+- **Status:** captured
+- **Category:** UX
+- **Raw request:** Drag an item from one section to another within the same store to reassign it. Currently section reassignment requires editing the item's properties — DnD would make this a single gesture. Emerged during #7 (item ordering) design discussion — section-ordered lists make section boundaries visually obvious, and dragging an item across a boundary to change its section is a natural UX.
+- **Context / notes:** Builds on #7's DnD infrastructure and ordered list display. Requires distinction between same-section reorder (update `Item.order`) and cross-section move (update `Item.sectionId` + `Item.order`). Edge case: where does the item land in the target section? At drop position or at end?
+- **Links:** #7

--- a/planning/tickets/item-ordering.md
+++ b/planning/tickets/item-ordering.md
@@ -1,0 +1,155 @@
+# Ticket: Per-store item ordering with auto-sort on add
+
+**Status:** planned
+**Source:** intake 2026-06-16, GROCERUN-7
+**Branch:** —
+
+## Background
+
+Items in shopping lists are already grouped by section. Within each section they appear in add-order (FIFO by `createdAt`). This ticket adds intra-section ordering so items within a section follow store-layout order rather than add-order.
+
+Sections already have `order` with working DnD reorder (`PATCH sections/reorder` + `SortableList`). Items have no `order` field — catalog listings sort by `purchaseCount DESC, name ASC`, list items sort by `createdAt ASC`.
+
+## User-Facing Goal
+
+Items in shopping lists display in store-layout order (sections → items). Adding a known item auto-lands in its section position. Reordering during a shopping trip persists to future trips for that store.
+
+## Acceptance Criteria
+
+- List items grouped by section, sorted within section by `item.order ASC NULLS LAST, item.name ASC`
+- DnD reorder within sections in **shopping mode only** — not planning mode
+- Reorder persists across lists for the same store
+- Adding an existing item to a list places it in its section position (natural consequence of sort key — no special code)
+- New items (never positioned, `order = NULL`) sort alphabetically within their section
+- Crash-safe: lost reorder is acceptable — user redoes next trip
+- Reorder sent as batch `PATCH items/reorder` on shopping mode end
+
+## Scope
+
+- Add `order Int?` (nullable) to `Item` model (Prisma + RxDB). `NULL` = unpositioned, non-`NULL` = positioned
+- Add `@@index([sectionId, order])`
+- `PATCH items/reorder` endpoint: `{ sectionId: string, storeId: string, orderedItemIds: string[] }`
+- `ReorderItemsSchema` DTO (Zod: `z.object({ sectionId, storeId, orderedItemIds })`)
+- `GET lists/:id`: sort key `section.order ASC, item.order ASC NULLS LAST, item.name ASC`
+- `ListItemWithItem` type: include `order: number | null`
+- RxDB `itemToSyncDoc`: include `order` in pull; push handler does NOT push `order` (server-authoritative)
+- `PATCH items/:id` does NOT accept `order` from body; if `sectionId` changes, reset `order` to `NULL`
+- Per-section DnD in list view (reuse `SortableList`) — shopping mode only
+- In-memory reorder diff during shopping, batch `PATCH items/reorder` on mode end
+- `useReorderItems` hook: direct `api.patch('/items/reorder', ...)` — NOT through RxDB push
+
+## Non-Scope
+
+- Aisles — section is the canonical term
+- Per-list custom ordering — all lists inherit catalog order
+- Cross-section drag-and-drop — logged as separate intake (FEATURE-INTAKE.md)
+- Store catalog reorder UI — **rejected.** Order mutations without a sync context (shopping mode) create data inconsistency risk
+- `PATCH items/:id` does NOT accept `order`
+- Periodic order compaction — integer growth is cosmetic at realistic scale
+- Reorder in planning mode — UI restricted to shopping mode only
+
+## Emergent Ordering
+
+Order is not pre-configured — it emerges from actual shopping trips. When new items appear alongside positioned items for the first time, the bump algorithm makes a **best guess** that places new items where the user dragged them relative to known items, but does not know their correct position relative to catalog items not in the current list.
+
+Order improves with each trip, converging toward true store layout without a settings page. If an item is never in a list alongside another, their relative order doesn't matter yet.
+
+## Relevant Context
+
+- Items already `storeId`-scoped in the current model
+- Only one active list per store — no concurrent reorder risk
+- `Section.order` + `PATCH sections/reorder` exists as reference pattern
+- `components/ui/sortable.tsx` (SortableList, SortableItem, SortableDragHandle) — proven DnD
+- `ListEditor.tsx` lines 313-325 already group list items by section
+- Shopping mode locks list-scope data but item ordering touches catalog data — acceptable: store-scope data editable outside shopping mode (store name, section order/name) does not intersect with `Item.order`
+
+## Affected Areas
+
+| Area | Files |
+|------|-------|
+| Prisma schema | `apps/server/prisma/schema.prisma` |
+| Migration | New migration file |
+| Server items | `apps/server/src/items/items.controller.ts`, `items.service.ts` |
+| Server lists | `apps/server/src/lists/lists.service.ts` |
+| Shared DTOs | `apps/_shared/dtos/src/index.ts` |
+| RxDB schema | `apps/web/src/core/rxdb/schema.ts` |
+| RxDB sync | `apps/server/src/sync/collections/item-sync.ts` |
+| RxDB mutations | `apps/web/src/core/lib/useRxMutation.ts` (no changes — order excluded from push) |
+| List view | `apps/web/src/features/lists/components/ListEditor.tsx` |
+| DnD | New hook `useReorderItems` (follows `useReorderSections` pattern) |
+
+## Implementation Outline
+
+### Part A — Schema + Server (2 days)
+1. Add `order Int?` to Prisma `Item`, add `@@index([sectionId, order])`, run migration
+2. Add `order?: number` to `ItemDocType` (optional, nullable)
+3. Add `ReorderItemsSchema` DTO: `{ sectionId: z.string(), storeId: z.string(), orderedItemIds: z.array(z.string()) }`
+4. `PATCH items/reorder` — bump+compact algorithm (transactional, `$transaction()`)
+5. Update `GET lists/:id` sort to `section.order ASC, item.order ASC NULLS LAST, item.name ASC`
+6. Update `itemToSyncDoc` to include `order` in pull; verify push handler excludes `order`
+7. Server unit tests: reorder endpoint, sort logic
+8. `PATCH items/:id`: reset `order` to `NULL` when `sectionId` changes
+
+### Part B — Web (2-3 days)
+1. `useReorderItems` hook: direct `api.patch('/items/reorder', ...)` — NOT RxDB push
+2. Per-section `SortableList` in `ListEditor` — shopping mode only
+3. In-memory reorder diff (array of `{ sectionId, orderedItemIds[] }` diffs), batch send on mode end
+4. List view sort by section→item order (natural consequence of updated `GET lists/:id`)
+5. Component tests for DnD, e2e for section-grouped order
+
+## Server Algorithm — Bump + Compact
+
+Operates per-section, server-side, within `this.prisma.$transaction()`.
+
+**Key invariant:** `NULL` = never positioned. Non-`NULL` = positioned. All positioned items form a contiguous block at the start of the section. Compaction maintains this.
+
+**Algorithm:**
+
+1. **Validate:** All `orderedItemIds` belong to `storeId`, match the given `sectionId`, and are not soft-deleted. Reject with 400 if any fail.
+
+2. **Read state:** Fetch all non-deleted items in the section: `{ id, order }`. Build `orderMap`. Unpositioned items have `order = null`.
+
+3. **Normalize:** Extract all positioned items from the reorder array (preserving array order). Check if their existing `order` values are strictly ascending left-to-right. An item is repositioned if its existing `order` does not match this linearization — i.e., it appears before an item with a lower `order` or after an item with a higher `order`. Repositioned items are treated as unpositioned for this run: remove their `order` from `orderMap`. Items with equal `order` values (shouldn't happen in practice) are both treated as repositioned.
+
+4. **Assign positions:** Iterate through the reorder array. For each item:
+   - If positioned (order in `orderMap`): it stays at its current order (already bumped as an anchor). Track as anchor.
+   - If unpositioned (no order in `orderMap`): insert before the next anchor. Count unpositioned items before that anchor. Bump the section: `UPDATE Item SET order = order + N WHERE sectionId = ? AND order >= anchorOrder AND deleted = false`. Assign the unpositioned block `[anchorOrder, anchorOrder + N - 1]` in reorder-array order. Update `orderMap` for bumped items.
+
+   **Tiebreaker for unpositioned items within a block:** reorder-array order for visible items. Invisible catalog items that get bumped are NOT assigned — they just get their order incremented and stay in `orderMap`.
+
+5. **Tail assignment:** After the last anchor, any remaining unpositioned items in the reorder array get assigned sequentially starting from `maxOrder + 1`.
+
+6. **Compaction:** After assignment, renumber all non-`NULL` items in the section to `1, 2, 3, ...` (consecutive, starting from 1). NULLs are not touched. This keeps integer values bounded and means `0` is never used (eliminating the `0`-as-sentinel problem entirely).
+
+7. **Notify:** `this.notify.byStore(storeId, ['item'])` — triggers RxDB pull for all connected clients.
+
+**All-NULL fallback:** If no item in the section has a non-`NULL` order, assign sequential positions from 1 in reorder-array order.
+
+**Crash safety:** Reorder diff held in memory. Crash = lost, user redoes next trip. Acceptable — item ordering is not transactional data.
+
+**Concurrent reorders:** `$transaction()` serializes. Last write wins. Acceptable given single active list per store.
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Section has no positioned items (all NULL) | Assign sequential from 1 in reorder-array order |
+| Item moved to different section via `PATCH items/:id` | `order` reset to `NULL` on section change |
+| Item soft-deleted then restored | `order` persists; gets normalized on next reorder |
+| New item added mid-trip (not in reorder diff) | Stays `NULL` until included in a future reorder |
+| Equal-order collision (two positioned items with same order) | Treated as repositioned by normalize step (not strictly monotonic) |
+| Empty reorder array | No-op (or reject with 400) |
+| Concurrent reorder from another device | `$transaction()` serializes; last-write-wins |
+
+## Test Strategy
+
+- **Unit (server):** bump algorithm with positioned + new items; all-NULL fallback; normalize step (non-monotonic detection); compaction produces consecutive 1..N; sectionId change resets order
+- **Component (web):** DnD within section (shopping mode only); sort order display
+- **E2E:** add items to list, reorder in shopping mode, end trip, reopen list — verify order persists
+- **Manual/UAT:** crash recovery acceptable (redo); offline reorder queued
+
+## Risks
+
+- **Offline + concurrent:** last-write-wins. Acceptable — single active list per store.
+- **In-memory reorder diff:** lost on crash. Acceptable — item ordering is not transactional.
+- **Nullable `order` + NULLS LAST:** Prisma typed API can't express `NULLS LAST` natively. Must sort in application code or use raw SQL. App-level sort (Option A from review) is recommended.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Household management actions now use permission-based controls for better clarity
* Contextual leave and delete buttons appear based on user role and membership status
* Owner-only operations are protected with permission validation
* Disabled state clearly indicates unavailable actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->