### PR TITLE
fix(auth): auto-refresh JWKS on Google key rotation to prevent login …

### DIFF
--- a/apps/_shared/dtos/package.json
+++ b/apps/_shared/dtos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grocerun/dto",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "test": "echo '⚠️  Run npm run dev first, then: npm run e2e:run' && exit 0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grocerun-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "build": "nest build",

--- a/apps/server/src/auth/oidc-server.ts
+++ b/apps/server/src/auth/oidc-server.ts
@@ -1,17 +1,84 @@
 import { oidcSpa, extractRequestAuthContext } from 'oidc-spa/server';
 import { z } from 'zod';
+import { Logger } from '@nestjs/common';
 
-export const { bootstrapAuth, validateAndDecodeAccessToken } = oidcSpa
-    .withExpectedDecodedAccessTokenShape({
-        decodedAccessTokenSchema: z.object({
-            sub: z.string(),
-            name: z.string().optional(),
-            email: z.string().email().optional(),
-            picture: z.string().url().optional(),
-            email_verified: z.boolean().optional(),
-        }),
-    })
-    .createUtils();
+const logger = new Logger('OidcServer');
+
+const oidcBuilder = oidcSpa.withExpectedDecodedAccessTokenShape({
+    decodedAccessTokenSchema: z.object({
+        sub: z.string(),
+        name: z.string().optional(),
+        email: z.string().email().optional(),
+        picture: z.string().url().optional(),
+        email_verified: z.boolean().optional(),
+    }),
+});
+
+let currentInstance = oidcBuilder.createUtils();
+let lastBootstrapParams: Parameters<typeof currentInstance.bootstrapAuth>[0] | null = null;
+
+// Coalesces concurrent JWKS refreshes so that only ONE bootstrap/JWKS fetch
+// happens when many requests fail simultaneously (e.g. the 7-parallel sync
+// pull burst seen in prod). Concurrent callers await the same in-flight
+// promise instead of each starting their own refresh.
+let refreshInFlight: Promise<typeof currentInstance | null> | null = null;
+
+export const bootstrapAuth = async (params: Parameters<typeof currentInstance.bootstrapAuth>[0]) => {
+    lastBootstrapParams = params;
+    await currentInstance.bootstrapAuth(params);
+};
+
+async function getRefreshedInstance(): Promise<typeof currentInstance | null> {
+    if (!lastBootstrapParams) {
+        logger.warn(`Cannot refresh JWKS: bootstrapAuth was never called with params.`);
+        return null;
+    }
+    const newInstance = oidcBuilder.createUtils();
+    await newInstance.bootstrapAuth(lastBootstrapParams);
+    return newInstance;
+}
+
+export const validateAndDecodeAccessToken = async (
+    params: Parameters<typeof currentInstance.validateAndDecodeAccessToken>[0]
+) => {
+    const result = await currentInstance.validateAndDecodeAccessToken(params);
+
+    if (
+        !result.isSuccess &&
+        result.debugErrorMessage &&
+        result.debugErrorMessage.includes('No public signing key found with kid')
+    ) {
+        if (!refreshInFlight) {
+            logger.warn(
+                `Key mismatch detected (kid not found). Coalescing a single JWKS refresh...`
+            );
+            refreshInFlight = getRefreshedInstance();
+        }
+
+        try {
+            const newInstance = await refreshInFlight;
+            if (newInstance) {
+                const retryResult = await newInstance.validateAndDecodeAccessToken(params);
+                if (retryResult.isSuccess) {
+                    logger.log(`JWKS refreshed successfully! Updating current OIDC client instance.`);
+                    currentInstance = newInstance;
+                    return retryResult;
+                }
+                logger.error(
+                    `JWKS refresh failed: retry validation still failed with: ${retryResult.debugErrorMessage}`
+                );
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            const stack = err instanceof Error ? err.stack : undefined;
+            logger.error(`Failed to refresh JWKS and re-authenticate: ${msg}`, stack);
+        } finally {
+            refreshInFlight = null;
+        }
+    }
+
+    return result;
+};
 
 // Re-export so guard can use it
 export { extractRequestAuthContext };

--- a/apps/server/test/auth/oidc-server.spec.ts
+++ b/apps/server/test/auth/oidc-server.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted to ensure these mocks are hoisted and available during vi.mock initialization
+const { mockBootstrapAuth, mockValidateAndDecodeAccessToken, mockCreateUtils } = vi.hoisted(() => {
+  const bootstrap = vi.fn();
+  const validate = vi.fn();
+  const create = vi.fn(() => ({
+    bootstrapAuth: bootstrap,
+    validateAndDecodeAccessToken: validate,
+  }));
+  return {
+    mockBootstrapAuth: bootstrap,
+    mockValidateAndDecodeAccessToken: validate,
+    mockCreateUtils: create,
+  };
+});
+
+vi.mock('oidc-spa/server', () => {
+  return {
+    extractRequestAuthContext: vi.fn(),
+    oidcSpa: {
+      withExpectedDecodedAccessTokenShape: () => ({
+        createUtils: mockCreateUtils,
+      }),
+    },
+  };
+});
+
+// Import after mocking
+import { bootstrapAuth, validateAndDecodeAccessToken } from '../../src/auth/oidc-server';
+
+describe('OidcServer Self-Healing Wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates successful validation directly to the active instance', async () => {
+    mockValidateAndDecodeAccessToken.mockResolvedValue({
+      isSuccess: true,
+      decodedAccessToken: { sub: 'user-123' },
+    });
+
+    const result = await validateAndDecodeAccessToken({ accessToken: 'valid-token' });
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.decodedAccessToken?.sub).toBe('user-123');
+    expect(mockValidateAndDecodeAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockCreateUtils).toHaveBeenCalledTimes(0); // No new instance created
+  });
+
+  it('automatically refreshes JWKS and retries validation when kid is missing', async () => {
+    // 1. Initial call to bootstrapAuth stores bootstrap parameters
+    await bootstrapAuth({
+      implementation: 'real',
+      issuerUri: 'https://accounts.google.com',
+      expectedAudience: 'some-client-id',
+    });
+
+    // 2. Setup first call to fail with kid mismatch, and second (on new instance) to succeed
+    let callCount = 0;
+    mockValidateAndDecodeAccessToken.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          isSuccess: false,
+          debugErrorMessage: 'No public signing key found with kid f36191371c',
+        };
+      }
+      return {
+        isSuccess: true,
+        decodedAccessToken: { sub: 'user-456' },
+      };
+    });
+
+    mockBootstrapAuth.mockResolvedValue(undefined);
+
+    const result = await validateAndDecodeAccessToken({ accessToken: 'new-kid-token' });
+
+    // Should return the successful retry result
+    expect(result.isSuccess).toBe(true);
+    expect(result.decodedAccessToken?.sub).toBe('user-456');
+
+    // Should have created a second instance of the OIDC client
+    expect(mockCreateUtils).toHaveBeenCalledTimes(1);
+    expect(mockBootstrapAuth).toHaveBeenCalledTimes(2); // Initial + Retry bootstrap
+  });
+
+  it('coalesces concurrent kid-missing refreshes into a single JWKS fetch', async () => {
+    await bootstrapAuth({
+      implementation: 'real',
+      issuerUri: 'https://accounts.google.com',
+    });
+
+    // All concurrent requests fail the first validation with kid-missing.
+    // After the single refreshed instance is ready, every caller's retry
+    // succeeds.
+    let firstCallCount = 0;
+    mockValidateAndDecodeAccessToken.mockImplementation(async () => {
+      firstCallCount++;
+      if (firstCallCount <= 7) {
+        return {
+          isSuccess: false,
+          debugErrorMessage: 'No public signing key found with kid rotated-kid',
+        };
+      }
+      return {
+        isSuccess: true,
+        decodedAccessToken: { sub: 'coalesced-user' },
+      };
+    });
+
+    // Delay the mock bootstrap on a macrotask so that all 7 concurrent
+    // callers latch onto the same in-flight refresh promise before it
+    // resolves (mirrors the real ~100ms+ JWKS fetch latency).
+    mockBootstrapAuth.mockImplementation(
+      () => new Promise<void>((r) => setTimeout(r, 0)),
+    );
+
+    const tokens = Array.from({ length: 7 }, (_, i) => `t-${i}`);
+    const results = await Promise.all(
+      tokens.map((t) => validateAndDecodeAccessToken({ accessToken: t })),
+    );
+
+    // Every caller succeeds after the shared refresh.
+    expect(results.every((r) => r.isSuccess)).toBe(true);
+
+    // Only ONE new OIDC instance was created and only ONE retry bootstrap
+    // served all 7 concurrent callers (setup bootstrap + 1 retry = 2 total;
+    // without coalescing it would be setup + 7 = 8).
+    expect(mockCreateUtils).toHaveBeenCalledTimes(1);
+    expect(mockBootstrapAuth).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns initial failure if retry also fails', async () => {
+    await bootstrapAuth({
+      implementation: 'real',
+      issuerUri: 'https://accounts.google.com',
+    });
+
+    mockValidateAndDecodeAccessToken.mockResolvedValue({
+      isSuccess: false,
+      debugErrorMessage: 'No public signing key found with kid f36191371c',
+    });
+
+    const result = await validateAndDecodeAccessToken({ accessToken: 'bad-token' });
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.debugErrorMessage).toContain('No public signing key found with kid');
+    expect(mockCreateUtils).toHaveBeenCalledTimes(1); // Tried once, failed, returned failure
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grocerun-web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grocerun-monorepo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "packageManager": "npm@10.9.4",
   "workspaces": [


### PR DESCRIPTION
…loops

Google rotates its OIDC signing keys every few weeks. When a token arrives with a kid not in oidc-spa's cached key set, the library returns 'No public signing key found with kid' without triggering its own JWKS refresh (evtInvalidSignature only fires on signature mismatch, and the kid-missing branch returns early). This left the server unable to validate any token signed with the rotated key, trapping users in a login loop.

Wrap validateAndDecodeAccessToken with a self-healing layer that, on kid-mismatch, coalesces a single JWKS refresh across concurrent callers (matches the 7-parallel sync pull burst seen in prod), retries against the fresh instance, and swaps it in for subsequent requests.

Bump version to 1.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication handling so access-token checks can recover automatically if a signing key changes, reducing failed logins during key refreshes.

* **Bug Fixes**
  * Concurrent authentication requests now share a single refresh attempt, helping avoid duplicate retries and improving reliability.
  * Updated package versions across the repository to `1.0.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->