### PR TITLE
fix(sync): collection-scoped SSE routing, skip self-notify, memoize a…

### DIFF
--- a/apps/server/src/households/households.service.ts
+++ b/apps/server/src/households/households.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { SseBroadcastService } from '../sync/sse-broadcast.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateHouseholdDto, UpdateHouseholdDto } from './dto/household.dto';
 import { cascadeSoftDeleteHousehold } from '../shared/cascade-soft-delete';
 
@@ -10,7 +10,7 @@ export class HouseholdsService {
   constructor(
     private prisma: PrismaService,
     private sseBroadcast: SseBroadcastService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async getHouseholds(userId: string) {
@@ -35,7 +35,7 @@ export class HouseholdsService {
       },
     });
 
-    this.notify.byHousehold(household.id, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(household.id, ['household', 'store'], 'household-mutation');
 
     return household;
   }
@@ -62,7 +62,7 @@ export class HouseholdsService {
       }
     });
 
-    this.notify.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
 
     return { success: true };
   }
@@ -91,7 +91,7 @@ export class HouseholdsService {
 
     this.sseBroadcast.notifyHouseholdRemoved([userId], householdId);
 
-    this.notify.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
 
     return { success: true };
   }
@@ -124,7 +124,7 @@ export class HouseholdsService {
 
     this.sseBroadcast.notifyHouseholdRemoved([userId], householdId);
 
-    this.notify.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
 
     return { success: true };
   }
@@ -165,7 +165,7 @@ export class HouseholdsService {
     // Notify the removed user so they can clean up their local state
     this.sseBroadcast.notifyHouseholdRemoved([memberUserId], householdId);
 
-    this.notify.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/households/households.service.ts
+++ b/apps/server/src/households/households.service.ts
@@ -4,6 +4,7 @@ import { SseBroadcastService } from '../sync/sse-broadcast.service';
 import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateHouseholdDto, UpdateHouseholdDto } from './dto/household.dto';
 import { cascadeSoftDeleteHousehold } from '../shared/cascade-soft-delete';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 @Injectable()
 export class HouseholdsService {
@@ -35,7 +36,7 @@ export class HouseholdsService {
       },
     });
 
-    this.sseSyncBroadcast.byHousehold(household.id, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(household.id, SYNC_CHANGE.household, 'household-mutation');
 
     return household;
   }
@@ -62,7 +63,7 @@ export class HouseholdsService {
       }
     });
 
-    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, SYNC_CHANGE.household, 'household-mutation');
 
     return { success: true };
   }
@@ -91,7 +92,7 @@ export class HouseholdsService {
 
     this.sseBroadcast.notifyHouseholdRemoved([userId], householdId);
 
-    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, SYNC_CHANGE.household, 'household-mutation');
 
     return { success: true };
   }
@@ -124,7 +125,7 @@ export class HouseholdsService {
 
     this.sseBroadcast.notifyHouseholdRemoved([userId], householdId);
 
-    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, SYNC_CHANGE.householdCascade, 'household-mutation');
 
     return { success: true };
   }
@@ -165,7 +166,7 @@ export class HouseholdsService {
     // Notify the removed user so they can clean up their local state
     this.sseBroadcast.notifyHouseholdRemoved([memberUserId], householdId);
 
-    this.sseSyncBroadcast.byHousehold(householdId, ['household', 'store'], 'household-mutation');
+    this.sseSyncBroadcast.byHousehold(householdId, SYNC_CHANGE.household, 'household-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/invitations/invitations.service.ts
+++ b/apps/server/src/invitations/invitations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { randomInt } from 'crypto';
 import { CreateInvitationDto, JoinHouseholdDto, RevokeInvitationDto } from './dto/invitation.dto';
 
@@ -19,7 +19,7 @@ function generateToken(): string {
 export class InvitationsService {
   constructor(
     private prisma: PrismaService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async createInvitation(dto: CreateInvitationDto, userId: string) {
@@ -111,7 +111,7 @@ export class InvitationsService {
       })
     ]);
 
-    this.notify.byHousehold(invitation.householdId, ['household'], 'invitation-mutation');
+    this.sseSyncBroadcast.byHousehold(invitation.householdId, ['household'], 'invitation-mutation');
 
     return { householdName: invitation.household.name };
   }

--- a/apps/server/src/invitations/invitations.service.ts
+++ b/apps/server/src/invitations/invitations.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma.service';
 import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { randomInt } from 'crypto';
 import { CreateInvitationDto, JoinHouseholdDto, RevokeInvitationDto } from './dto/invitation.dto';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 // Use a readable alphabet for tokens (no confusing chars like 0/O, 1/l)
 const TOKEN_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ';
@@ -111,7 +112,7 @@ export class InvitationsService {
       })
     ]);
 
-    this.sseSyncBroadcast.byHousehold(invitation.householdId, ['household'], 'invitation-mutation');
+    this.sseSyncBroadcast.byHousehold(invitation.householdId, SYNC_CHANGE.householdCascade, 'invitation-mutation');
 
     return { householdName: invitation.household.name };
   }

--- a/apps/server/src/items/items.service.ts
+++ b/apps/server/src/items/items.service.ts
@@ -4,7 +4,7 @@ import { SearchItemsSchema, GetTopItemsSchema } from '@grocerun/dto';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { UpdateItemDto } from './dto/update-item.dto';
 
 type SearchItemsParams = z.infer<typeof SearchItemsSchema>;
@@ -16,7 +16,7 @@ export class ItemsService {
   constructor(
     private prisma: PrismaService,
     private access: AccessService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async updateItem(itemId: string, dto: UpdateItemDto, userId: string) {
@@ -45,7 +45,7 @@ export class ItemsService {
 
     // 3. Notify other household members via SSE (fire-and-forget —
     //    failure must never block the REST response).
-    this.notify.byStore(item.storeId, ['item'], 'item-updated');
+    this.sseSyncBroadcast.byStore(item.storeId, ['item'], 'item-updated');
 
     return { status: 'UPDATED' };
   }

--- a/apps/server/src/items/items.service.ts
+++ b/apps/server/src/items/items.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
 import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { UpdateItemDto } from './dto/update-item.dto';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 type SearchItemsParams = z.infer<typeof SearchItemsSchema>;
 
@@ -45,7 +46,7 @@ export class ItemsService {
 
     // 3. Notify other household members via SSE (fire-and-forget —
     //    failure must never block the REST response).
-    this.sseSyncBroadcast.byStore(item.storeId, ['item'], 'item-updated');
+    this.sseSyncBroadcast.byStore(item.storeId, SYNC_CHANGE.item, 'item-updated');
 
     return { status: 'UPDATED' };
   }

--- a/apps/server/src/lists/lists.service.ts
+++ b/apps/server/src/lists/lists.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateListDto } from './dto/create-list.dto';
 import { AddItemDto } from './dto/add-item.dto';
 import { ToggleItemDto, UpdateQuantityDto } from './dto/manage-items.dto';
@@ -39,7 +39,7 @@ export class ListsService {
   constructor(
     private prisma: PrismaService,
     private access: AccessService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async createList(dto: CreateListDto, userId: string) {
@@ -65,7 +65,7 @@ export class ListsService {
       },
     });
 
-    this.notify.byStore(dto.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(dto.storeId, ['list', 'listItem'], 'list-mutation');
 
     return list;
   }
@@ -234,7 +234,7 @@ export class ListsService {
       });
     });
 
-    this.notify.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
     return listItem;
   }
 
@@ -278,7 +278,7 @@ export class ListsService {
       }
     });
 
-    this.notify.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }
@@ -310,7 +310,7 @@ export class ListsService {
       }
     });
 
-    this.notify.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }
@@ -337,7 +337,7 @@ export class ListsService {
       data: { deleted: true, deletedAt: new Date() }
     });
 
-    this.notify.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }
@@ -384,7 +384,7 @@ export class ListsService {
       }
     });
 
-    this.notify.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }
@@ -412,7 +412,7 @@ export class ListsService {
       data: { status: 'SHOPPING', assignedTo: assignedToId }
     });
 
-    this.notify.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }
@@ -439,7 +439,7 @@ export class ListsService {
       data: { status: 'PLANNING', assignedTo: null }
     });
 
-    this.notify.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
 
     return { success: true };
   }}

--- a/apps/server/src/lists/lists.service.ts
+++ b/apps/server/src/lists/lists.service.ts
@@ -5,6 +5,7 @@ import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateListDto } from './dto/create-list.dto';
 import { AddItemDto } from './dto/add-item.dto';
 import { ToggleItemDto, UpdateQuantityDto } from './dto/manage-items.dto';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 export interface ListItemWithItem {
   id: string;
@@ -65,7 +66,7 @@ export class ListsService {
       },
     });
 
-    this.sseSyncBroadcast.byStore(dto.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(dto.storeId, SYNC_CHANGE.list, 'list-mutation');
 
     return list;
   }
@@ -234,7 +235,7 @@ export class ListsService {
       });
     });
 
-    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, SYNC_CHANGE.listItemWithItem, 'list-mutation');
     return listItem;
   }
 
@@ -278,7 +279,7 @@ export class ListsService {
       }
     });
 
-    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, SYNC_CHANGE.listItem, 'list-mutation');
 
     return { success: true };
   }
@@ -310,7 +311,7 @@ export class ListsService {
       }
     });
 
-    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, SYNC_CHANGE.listItem, 'list-mutation');
 
     return { success: true };
   }
@@ -337,7 +338,7 @@ export class ListsService {
       data: { deleted: true, deletedAt: new Date() }
     });
 
-    this.sseSyncBroadcast.byStore(listItem.list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(listItem.list.storeId, SYNC_CHANGE.listItem, 'list-mutation');
 
     return { success: true };
   }
@@ -384,7 +385,7 @@ export class ListsService {
       }
     });
 
-    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, SYNC_CHANGE.completedList, 'list-mutation');
 
     return { success: true };
   }
@@ -412,7 +413,7 @@ export class ListsService {
       data: { status: 'SHOPPING', assignedTo: assignedToId }
     });
 
-    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, SYNC_CHANGE.list, 'list-mutation');
 
     return { success: true };
   }
@@ -439,7 +440,7 @@ export class ListsService {
       data: { status: 'PLANNING', assignedTo: null }
     });
 
-    this.sseSyncBroadcast.byStore(list.storeId, ['list', 'listItem'], 'list-mutation');
+    this.sseSyncBroadcast.byStore(list.storeId, SYNC_CHANGE.list, 'list-mutation');
 
     return { success: true };
   }}

--- a/apps/server/src/sections/sections.service.ts
+++ b/apps/server/src/sections/sections.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateSectionDto, UpdateSectionDto, ReorderSectionsDto } from './dto/section.dto';
 
 @Injectable()
@@ -9,7 +9,7 @@ export class SectionsService {
   constructor(
     private prisma: PrismaService,
     private access: AccessService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async getSections(storeId: string, userId: string) {
@@ -56,7 +56,7 @@ export class SectionsService {
       },
     });
 
-    this.notify.byStore(dto.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(dto.storeId, ['section'], 'section-mutation');
 
     return section;
   }
@@ -77,7 +77,7 @@ export class SectionsService {
       data: { name: dto.name },
     });
 
-    this.notify.byStore(section.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(section.storeId, ['section'], 'section-mutation');
 
     return { success: true };
   }
@@ -108,7 +108,7 @@ export class SectionsService {
       });
     });
 
-    this.notify.byStore(section.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(section.storeId, ['section'], 'section-mutation');
 
     return { success: true };
   }
@@ -138,7 +138,7 @@ export class SectionsService {
       )
     );
 
-    this.notify.byStore(storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(storeId, ['section'], 'section-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/sections/sections.service.ts
+++ b/apps/server/src/sections/sections.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
 import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateSectionDto, UpdateSectionDto, ReorderSectionsDto } from './dto/section.dto';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 @Injectable()
 export class SectionsService {
@@ -56,7 +57,7 @@ export class SectionsService {
       },
     });
 
-    this.sseSyncBroadcast.byStore(dto.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(dto.storeId, SYNC_CHANGE.section, 'section-mutation');
 
     return section;
   }
@@ -77,7 +78,7 @@ export class SectionsService {
       data: { name: dto.name },
     });
 
-    this.sseSyncBroadcast.byStore(section.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(section.storeId, SYNC_CHANGE.section, 'section-mutation');
 
     return { success: true };
   }
@@ -108,7 +109,7 @@ export class SectionsService {
       });
     });
 
-    this.sseSyncBroadcast.byStore(section.storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(section.storeId, SYNC_CHANGE.sectionWithItemReassignment, 'section-mutation');
 
     return { success: true };
   }
@@ -138,7 +139,7 @@ export class SectionsService {
       )
     );
 
-    this.sseSyncBroadcast.byStore(storeId, ['section'], 'section-mutation');
+    this.sseSyncBroadcast.byStore(storeId, SYNC_CHANGE.section, 'section-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/shared/shared.module.ts
+++ b/apps/server/src/shared/shared.module.ts
@@ -2,11 +2,11 @@ import { Global, Module } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { SseBroadcastService } from '../sync/sse-broadcast.service';
 import { AccessService } from './access.service';
-import { NotificationService } from './notification.service';
+import { SseSyncBroadcastService } from './sse-sync-broadcast.service';
 
 @Global()
 @Module({
-  providers: [AccessService, NotificationService, PrismaService, SseBroadcastService],
-  exports: [AccessService, NotificationService, PrismaService, SseBroadcastService],
+  providers: [AccessService, SseSyncBroadcastService, PrismaService, SseBroadcastService],
+  exports: [AccessService, SseSyncBroadcastService, PrismaService, SseBroadcastService],
 })
 export class SharedModule {}

--- a/apps/server/src/shared/sse-sync-broadcast.service.ts
+++ b/apps/server/src/shared/sse-sync-broadcast.service.ts
@@ -3,8 +3,8 @@ import { PrismaService } from '../prisma.service';
 import { SseBroadcastService } from '../sync/sse-broadcast.service';
 
 @Injectable()
-export class NotificationService {
-  private readonly logger = new Logger(NotificationService.name);
+export class SseSyncBroadcastService {
+  private readonly logger = new Logger(SseSyncBroadcastService.name);
 
   constructor(
     private prisma: PrismaService,

--- a/apps/server/src/shared/sse-sync-broadcast.service.ts
+++ b/apps/server/src/shared/sse-sync-broadcast.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { SseBroadcastService } from '../sync/sse-broadcast.service';
+import { SyncCollection } from './sync-change';
 
 @Injectable()
 export class SseSyncBroadcastService {
@@ -15,7 +16,7 @@ export class SseSyncBroadcastService {
    * Notify all household members by looking up the store's household.
    * Fire-and-forget — failure must never block the mutation.
    */
-  byStore(storeId: string, collections: string[], reason: string) {
+  byStore(storeId: string, collections: readonly SyncCollection[], reason: string) {
     this.prisma.store
       .findUnique({
         where: { id: storeId },
@@ -42,7 +43,7 @@ export class SseSyncBroadcastService {
    * Notify all household members by household ID.
    * Fire-and-forget — failure must never block the mutation.
    */
-  byHousehold(householdId: string, collections: string[], reason: string) {
+  byHousehold(householdId: string, collections: readonly SyncCollection[], reason: string) {
     this.prisma.household
       .findUnique({
         where: { id: householdId },

--- a/apps/server/src/shared/sync-change.ts
+++ b/apps/server/src/shared/sync-change.ts
@@ -1,0 +1,31 @@
+/**
+ * Replicated document types named in SYNC_CHANGED event payloads.
+ *
+ * A manifest is a correctness contract: every collection whose documents can
+ * be changed by an operation must be named so connected clients pull its
+ * canonical server state.
+ */
+export const SYNC_COLLECTIONS = [
+  'household',
+  'store',
+  'section',
+  'item',
+  'list',
+  'listItem',
+] as const;
+
+export type SyncCollection = (typeof SYNC_COLLECTIONS)[number];
+
+export const SYNC_CHANGE = {
+  household: ['household'],
+  householdCascade: SYNC_COLLECTIONS,
+  store: ['store'],
+  storeCascade: ['store', 'section', 'item', 'list', 'listItem'],
+  section: ['section'],
+  sectionWithItemReassignment: ['section', 'item'],
+  item: ['item'],
+  list: ['list'],
+  listItem: ['listItem'],
+  listItemWithItem: ['item', 'listItem'],
+  completedList: ['list', 'item', 'listItem'],
+} as const satisfies Record<string, readonly SyncCollection[]>;

--- a/apps/server/src/stores/stores.service.ts
+++ b/apps/server/src/stores/stores.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { AccessService } from '../shared/access.service';
-import { NotificationService } from '../shared/notification.service';
+import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateStoreDto, UpdateStoreDto } from './dto/store.dto';
 import { cascadeSoftDeleteStore } from '../shared/cascade-soft-delete';
 
@@ -10,7 +10,7 @@ export class StoresService {
   constructor(
     private prisma: PrismaService,
     private access: AccessService,
-    private notify: NotificationService,
+    private sseSyncBroadcast: SseSyncBroadcastService,
   ) {}
 
   async getStores(householdId: string | undefined, userId: string) {
@@ -63,7 +63,7 @@ export class StoresService {
       },
     });
 
-    this.notify.byHousehold(dto.householdId, ['store', 'section'], 'store-mutation');
+    this.sseSyncBroadcast.byHousehold(dto.householdId, ['store', 'section'], 'store-mutation');
 
     return store;
   }
@@ -81,7 +81,7 @@ export class StoresService {
     });
 
     const store = await this.prisma.store.findUnique({ where: { id: storeId }, select: { householdId: true } });
-    if (store) this.notify.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
+    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
 
     return { success: true };
   }
@@ -96,7 +96,7 @@ export class StoresService {
     });
 
     const store = await this.prisma.store.findUnique({ where: { id: storeId }, select: { householdId: true } });
-    if (store) this.notify.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
+    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/stores/stores.service.ts
+++ b/apps/server/src/stores/stores.service.ts
@@ -4,6 +4,7 @@ import { AccessService } from '../shared/access.service';
 import { SseSyncBroadcastService } from '../shared/sse-sync-broadcast.service';
 import { CreateStoreDto, UpdateStoreDto } from './dto/store.dto';
 import { cascadeSoftDeleteStore } from '../shared/cascade-soft-delete';
+import { SYNC_CHANGE } from '../shared/sync-change';
 
 @Injectable()
 export class StoresService {
@@ -63,7 +64,7 @@ export class StoresService {
       },
     });
 
-    this.sseSyncBroadcast.byHousehold(dto.householdId, ['store', 'section'], 'store-mutation');
+    this.sseSyncBroadcast.byHousehold(dto.householdId, SYNC_CHANGE.store, 'store-mutation');
 
     return store;
   }
@@ -81,7 +82,7 @@ export class StoresService {
     });
 
     const store = await this.prisma.store.findUnique({ where: { id: storeId }, select: { householdId: true } });
-    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
+    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, SYNC_CHANGE.store, 'store-mutation');
 
     return { success: true };
   }
@@ -96,7 +97,7 @@ export class StoresService {
     });
 
     const store = await this.prisma.store.findUnique({ where: { id: storeId }, select: { householdId: true } });
-    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, ['store', 'section'], 'store-mutation');
+    if (store) this.sseSyncBroadcast.byHousehold(store.householdId, SYNC_CHANGE.storeCascade, 'store-mutation');
 
     return { success: true };
   }

--- a/apps/server/src/sync/sse-broadcast.service.ts
+++ b/apps/server/src/sync/sse-broadcast.service.ts
@@ -37,9 +37,10 @@ export class SseBroadcastService {
     };
   }
 
-  notifyChanged(userIds: string[], payload: { collections: string[]; reason: string }) {
+  notifyChanged(userIds: string[], payload: { collections: string[]; reason: string }, excludeUserId?: string) {
     const data = JSON.stringify(payload);
     for (const userId of userIds) {
+      if (excludeUserId && userId === excludeUserId) continue;
       const set = this.connections.get(userId);
       if (!set) continue;
       for (const res of set) {

--- a/apps/server/src/sync/sse-broadcast.service.ts
+++ b/apps/server/src/sync/sse-broadcast.service.ts
@@ -37,10 +37,9 @@ export class SseBroadcastService {
     };
   }
 
-  notifyChanged(userIds: string[], payload: { collections: string[]; reason: string }, excludeUserId?: string) {
+  notifyChanged(userIds: string[], payload: { collections: readonly string[]; reason: string }) {
     const data = JSON.stringify(payload);
     for (const userId of userIds) {
-      if (excludeUserId && userId === excludeUserId) continue;
       const set = this.connections.get(userId);
       if (!set) continue;
       for (const res of set) {

--- a/apps/server/src/sync/sync.controller.ts
+++ b/apps/server/src/sync/sync.controller.ts
@@ -76,6 +76,7 @@ export class SyncController {
       this.sseBroadcast.notifyChanged(
         memberIds.length > 0 ? memberIds : [user.userId!],
         { collections: [collection], reason: `${collection}.push` },
+        user.userId!,
       );
     }
 

--- a/apps/server/src/sync/sync.controller.ts
+++ b/apps/server/src/sync/sync.controller.ts
@@ -76,7 +76,6 @@ export class SyncController {
       this.sseBroadcast.notifyChanged(
         memberIds.length > 0 ? memberIds : [user.userId!],
         { collections: [collection], reason: `${collection}.push` },
-        user.userId!,
       );
     }
 
@@ -128,9 +127,10 @@ export class SyncController {
     // Register this connection for broadcast notifications.
     const unregister = this.sseBroadcast.register(userId, res);
 
-    // Heartbeat every 15s to keep the connection alive through proxies/load balancers
+    // Named heartbeat lets the client reset its inactivity watchdog while also
+    // keeping the connection alive through proxies/load balancers.
     const heartbeat = setInterval(() => {
-      res.write(': heartbeat\n\n');
+      res.write('event: HEARTBEAT\ndata: {}\n\n');
     }, 15000);
 
     // Clean up when client disconnects

--- a/apps/server/src/sync/sync.module.ts
+++ b/apps/server/src/sync/sync.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
 import { SyncController } from './sync.controller';
 import { SyncService } from './sync.service';
-import { SseBroadcastService } from './sse-broadcast.service';
 
 @Module({
   controllers: [SyncController],
-  providers: [SyncService, SseBroadcastService],
-  exports: [SseBroadcastService],
+  providers: [SyncService],
 })
 export class SyncModule {}

--- a/apps/server/src/sync/sync.service.ts
+++ b/apps/server/src/sync/sync.service.ts
@@ -28,6 +28,9 @@ const MAX_BATCH_SIZE = 500;
 
 @Injectable()
 export class SyncService {
+  /** Per-request memo cache for access queries, cleared at the start of each pull/push. */
+  private accessCache = new Map<string, Promise<string[]>>();
+
   constructor(private prisma: PrismaService) {}
 
   private get deps(): SyncDeps {
@@ -35,8 +38,20 @@ export class SyncService {
       prisma: this.prisma,
       getAccessibleStoreIds: (userId) => this.getAccessibleStoreIds(userId),
       getAccessibleHouseholdIds: (userId) => this.getAccessibleHouseholdIds(userId),
-      getAccessibleStoreIdsForSync: (userId) => this.getAccessibleStoreIdsForSync(userId),
-      getAccessibleHouseholdIdsForSync: (userId) => this.getAccessibleHouseholdIdsForSync(userId),
+      getAccessibleStoreIdsForSync: (userId) => {
+        const key = `storeIdsForSync:${userId}`;
+        if (!this.accessCache.has(key)) {
+          this.accessCache.set(key, this.getAccessibleStoreIdsForSync(userId));
+        }
+        return this.accessCache.get(key)!;
+      },
+      getAccessibleHouseholdIdsForSync: (userId) => {
+        const key = `householdIdsForSync:${userId}`;
+        if (!this.accessCache.has(key)) {
+          this.accessCache.set(key, this.getAccessibleHouseholdIdsForSync(userId));
+        }
+        return this.accessCache.get(key)!;
+      },
       verifyStoreAccess: (storeId, userId) => this.verifyStoreAccess(storeId, userId),
       verifyHouseholdAccess: (householdId, userId) => this.verifyHouseholdAccess(householdId, userId),
     };
@@ -52,6 +67,7 @@ export class SyncService {
     batchSize: number,
     userId: string,
   ): Promise<PullResponse> {
+    this.accessCache.clear();
     this.assertCollection(collection);
     const limit = Math.min(batchSize || DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE);
 
@@ -81,6 +97,7 @@ export class SyncService {
     userId: string,
     shoppingLockId?: string,
   ): Promise<PushResponse> {
+    this.accessCache.clear();
     this.assertCollection(collection);
 
     if (!Array.isArray(rows) || rows.length === 0) {

--- a/apps/server/src/sync/sync.service.ts
+++ b/apps/server/src/sync/sync.service.ts
@@ -12,6 +12,7 @@ import { pullStores } from './collections/store-sync';
 import { pullHouseholds } from './collections/household-sync';
 import { SyncDeps } from './sync-deps';
 import { TOMBSTONE_WINDOW_MS } from './sync-helpers';
+import { SYNC_COLLECTIONS, SyncCollection } from '../shared/sync-change';
 import {
   PullResponse,
   PushRow,
@@ -19,39 +20,42 @@ import {
   SyncCheckpoint,
 } from './sync.types';
 
-export type SyncCollection = 'section' | 'item' | 'list' | 'listItem' | 'store' | 'household';
-
-const SUPPORTED_COLLECTIONS: readonly SyncCollection[] = ['section', 'item', 'list', 'listItem', 'store', 'household'];
+export type { SyncCollection } from '../shared/sync-change';
 
 const DEFAULT_BATCH_SIZE = 100;
 const MAX_BATCH_SIZE = 500;
 
 @Injectable()
 export class SyncService {
-  /** Per-request memo cache for access queries, cleared at the start of each pull/push. */
-  private accessCache = new Map<string, Promise<string[]>>();
-
   constructor(private prisma: PrismaService) {}
 
-  private get deps(): SyncDeps {
+  /**
+   * Creates dependencies for one pull or push operation.
+   *
+   * SyncService is a singleton, so a field-level cache would let concurrent
+   * requests clear or reuse one another's promises. Keeping this cache in the
+   * operation closure preserves memoization without crossing request bounds.
+   */
+  private createDeps(): SyncDeps {
+    const accessCache = new Map<string, Promise<string[]>>();
+
+    const getCachedAccess = (key: string, load: () => Promise<string[]>) => {
+      const cached = accessCache.get(key);
+      if (cached) return cached;
+
+      const value = load();
+      accessCache.set(key, value);
+      return value;
+    };
+
     return {
       prisma: this.prisma,
       getAccessibleStoreIds: (userId) => this.getAccessibleStoreIds(userId),
       getAccessibleHouseholdIds: (userId) => this.getAccessibleHouseholdIds(userId),
-      getAccessibleStoreIdsForSync: (userId) => {
-        const key = `storeIdsForSync:${userId}`;
-        if (!this.accessCache.has(key)) {
-          this.accessCache.set(key, this.getAccessibleStoreIdsForSync(userId));
-        }
-        return this.accessCache.get(key)!;
-      },
-      getAccessibleHouseholdIdsForSync: (userId) => {
-        const key = `householdIdsForSync:${userId}`;
-        if (!this.accessCache.has(key)) {
-          this.accessCache.set(key, this.getAccessibleHouseholdIdsForSync(userId));
-        }
-        return this.accessCache.get(key)!;
-      },
+      getAccessibleStoreIdsForSync: (userId) =>
+        getCachedAccess(`storeIdsForSync:${userId}`, () => this.getAccessibleStoreIdsForSync(userId)),
+      getAccessibleHouseholdIdsForSync: (userId) =>
+        getCachedAccess(`householdIdsForSync:${userId}`, () => this.getAccessibleHouseholdIdsForSync(userId)),
       verifyStoreAccess: (storeId, userId) => this.verifyStoreAccess(storeId, userId),
       verifyHouseholdAccess: (householdId, userId) => this.verifyHouseholdAccess(householdId, userId),
     };
@@ -67,23 +71,23 @@ export class SyncService {
     batchSize: number,
     userId: string,
   ): Promise<PullResponse> {
-    this.accessCache.clear();
     this.assertCollection(collection);
+    const deps = this.createDeps();
     const limit = Math.min(batchSize || DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE);
 
     switch (collection) {
       case 'section':
-        return pullSections(this.deps, checkpoint, limit, userId);
+        return pullSections(deps, checkpoint, limit, userId);
       case 'item':
-        return pullItems(this.deps, checkpoint, limit, userId);
+        return pullItems(deps, checkpoint, limit, userId);
       case 'list':
-        return pullLists(this.deps, checkpoint, limit, userId);
+        return pullLists(deps, checkpoint, limit, userId);
       case 'listItem':
-        return pullListItems(this.deps, checkpoint, limit, userId);
+        return pullListItems(deps, checkpoint, limit, userId);
       case 'store':
-        return pullStores(this.deps, checkpoint, limit, userId);
+        return pullStores(deps, checkpoint, limit, userId);
       case 'household':
-        return pullHouseholds(this.deps, checkpoint, limit, userId);
+        return pullHouseholds(deps, checkpoint, limit, userId);
     }
   }
 
@@ -97,8 +101,8 @@ export class SyncService {
     userId: string,
     shoppingLockId?: string,
   ): Promise<PushResponse> {
-    this.accessCache.clear();
     this.assertCollection(collection);
+    const deps = this.createDeps();
 
     if (!Array.isArray(rows) || rows.length === 0) {
       return [];
@@ -107,9 +111,9 @@ export class SyncService {
     switch (collection) {
       // ── Local-first collections (active shopping) ──────────────────
       case 'item':
-        return pushItems(this.deps, rows, userId);
+        return pushItems(deps, rows, userId);
       case 'listItem':
-        return pushListItems(this.deps, rows, userId, shoppingLockId ?? userId);
+        return pushListItems(deps, rows, userId, shoppingLockId ?? userId);
 
       // ── Server-authoritative collections (no local-first writes) ───
       // All mutations for section, list, store, and household go through
@@ -268,7 +272,7 @@ export class SyncService {
   }
 
   private assertCollection(collection: string): asserts collection is SyncCollection {
-    if (!SUPPORTED_COLLECTIONS.includes(collection as SyncCollection)) {
+    if (!SYNC_COLLECTIONS.includes(collection as SyncCollection)) {
       throw new NotFoundException(`Unknown sync collection: ${collection}`);
     }
   }

--- a/apps/server/test/sync/sse-broadcast.spec.ts
+++ b/apps/server/test/sync/sse-broadcast.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for SseBroadcastService notifyChanged broadcasting.
+ *
+ * GROCERUN-61 — SSE transport over-fetch regression tests. The three
+ * behaviors covered here shipped with zero tests:
+ *   1. notifyChanged reaches every registered household member
+ *   2. multiple connections for the same user each receive the payload
+ *   3. a user with no connection does not prevent other users from receiving
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Response } from 'express';
+import { SseBroadcastService } from '../../src/sync/sse-broadcast.service';
+
+function fakeResponse() {
+  return { write: vi.fn() } as unknown as Response;
+}
+
+describe('SseBroadcastService.notifyChanged', () => {
+  it('reaches every registered household member', () => {
+    const service = new SseBroadcastService();
+    const alice = fakeResponse();
+    const bob = fakeResponse();
+    service.register('alice', alice);
+    service.register('bob', bob);
+
+    const payload = { collections: ['list'], reason: 'list.push' };
+    service.notifyChanged(['alice', 'bob'], payload);
+
+    expect(alice.write).toHaveBeenCalledTimes(1);
+    expect(bob.write).toHaveBeenCalledTimes(1);
+    expect(alice.write).toHaveBeenCalledWith(
+      `event: SYNC_CHANGED\ndata: ${JSON.stringify(payload)}\n\n`,
+    );
+    expect(bob.write).toHaveBeenCalledWith(
+      `event: SYNC_CHANGED\ndata: ${JSON.stringify(payload)}\n\n`,
+    );
+  });
+
+  it('reaches every connection belonging to the pushing user', () => {
+    const service = new SseBroadcastService();
+    const firstTab = fakeResponse();
+    const secondTab = fakeResponse();
+    service.register('alice', firstTab);
+    service.register('alice', secondTab);
+
+    const payload = { collections: ['item'], reason: 'item.push' };
+    service.notifyChanged(['alice'], payload);
+
+    expect(firstTab.write).toHaveBeenCalledTimes(1);
+    expect(secondTab.write).toHaveBeenCalledTimes(1);
+    const frame = `event: SYNC_CHANGED\ndata: ${JSON.stringify(payload)}\n\n`;
+    expect(firstTab.write).toHaveBeenCalledWith(frame);
+    expect(secondTab.write).toHaveBeenCalledWith(frame);
+  });
+
+  it('notifies connected users when another household member has no connection', () => {
+    const service = new SseBroadcastService();
+    const alice = fakeResponse();
+    service.register('alice', alice);
+
+    const payload = { collections: ['store'], reason: 'store.push' };
+    service.notifyChanged(['alice', 'offline-user'], payload);
+
+    expect(alice.write).toHaveBeenCalledTimes(1);
+    expect(alice.write).toHaveBeenCalledWith(
+      `event: SYNC_CHANGED\ndata: ${JSON.stringify(payload)}\n\n`,
+    );
+  });
+});

--- a/apps/server/test/sync/sse-notify.spec.ts
+++ b/apps/server/test/sync/sse-notify.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration tests for SSE broadcast wiring on the sync push path.
+ *
+ * GROCERUN-61 — SSE transport over-fetch regression tests. These two
+ * behaviors shipped with zero tests:
+ *   4. Push broadcasts to every household connection, including the pusher,
+ *      with a collection-scoped payload for canonical-state reconciliation.
+ *   5. REST mutations advertise every replicated collection modified by a
+ *      cascade or server-side side effect.
+ */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { INestApplication } from '@nestjs/common';
+import {
+  createTestApp,
+  agent,
+  db,
+  seedBaseFixtures,
+  clearDomainData,
+  waitForAppReady,
+  TEST_USER_ID,
+} from '../helpers';
+import { SseBroadcastService } from '../../src/sync/sse-broadcast.service';
+
+let app: INestApplication;
+let householdId: string;
+let storeId: string;
+let sectionId: string;
+let notifySpy: ReturnType<typeof vi.spyOn>;
+
+beforeAll(async () => {
+  app = await createTestApp();
+  await waitForAppReady(app);
+  notifySpy = vi.spyOn(app.get(SseBroadcastService), 'notifyChanged');
+});
+
+afterAll(async () => {
+  notifySpy.mockRestore();
+  await app.close();
+});
+
+beforeEach(async () => {
+  await clearDomainData(db(app));
+  const fixtures = await seedBaseFixtures(db(app));
+  householdId = fixtures.householdId;
+  const storeRes = await agent(app)
+    .post('/stores')
+    .send({ name: 'SSE Test Store', householdId })
+    .expect(201);
+  storeId = storeRes.body.id;
+  const sectionRes = await agent(app)
+    .post('/sections')
+    .send({ name: 'SSE Test Section', storeId })
+    .expect(201);
+  sectionId = sectionRes.body.id;
+  await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledTimes(2));
+  notifySpy.mockClear();
+});
+
+afterEach(() => {
+  notifySpy.mockClear();
+});
+
+describe('sync push broadcast', () => {
+  it('notifies the pusher with a collection-scoped payload', async () => {
+    const now = new Date().toISOString();
+    await agent(app)
+      .post('/sync/item/push')
+      .send([
+        {
+          newDocumentState: {
+            id: 'sse-notify-item-1',
+            name: 'Push-Notified Item',
+            storeId,
+            sectionId,
+            defaultUnit: 'piece',
+            updatedAt: now,
+          },
+          assumedMasterState: null,
+        },
+      ])
+      .expect(200);
+
+    await vi.waitFor(() => expect(notifySpy).toHaveBeenCalled());
+    expect(notifySpy).toHaveBeenCalledWith(
+      [TEST_USER_ID],
+      { collections: ['item'], reason: 'item.push' },
+    );
+  });
+});
+
+async function expectOneBroadcast(collections: string[]) {
+  await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledTimes(1));
+  const [userIds, payload] = notifySpy.mock.calls[0];
+  expect(userIds).toContain(TEST_USER_ID);
+  expect(payload).toEqual({ collections, reason: expect.any(String) });
+}
+
+async function clearAfterBroadcast() {
+  await vi.waitFor(() => expect(notifySpy).toHaveBeenCalled());
+  notifySpy.mockClear();
+}
+
+describe('REST mutation broadcast manifests', () => {
+  it('notifies the mutator after a store create', async () => {
+    await agent(app)
+      .post('/stores')
+      .send({ name: 'REST-Notify Store', householdId })
+      .expect(201);
+
+    await expectOneBroadcast(['store']);
+  });
+
+  it('includes every child collection after a store cascade delete', async () => {
+    await agent(app)
+      .post('/lists')
+      .send({ storeId, name: 'Cascade list' })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app)
+      .post('/lists/items/add')
+      .send({ listId: (await db(app).list.findFirst({ where: { storeId, deleted: false } }))!.id, name: 'Cascade item', sectionId, quantity: 1 })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app).delete(`/stores/${storeId}`).expect(200);
+
+    await expectOneBroadcast(['store', 'section', 'item', 'list', 'listItem']);
+  });
+
+  it('includes items when deleting a section reassigns them', async () => {
+    await agent(app)
+      .post('/lists')
+      .send({ storeId, name: 'Section cascade list' })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app)
+      .post('/lists/items/add')
+      .send({ listId: (await db(app).list.findFirst({ where: { storeId, deleted: false } }))!.id, name: 'Section cascade item', sectionId, quantity: 1 })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app).delete(`/sections/${sectionId}`).expect(200);
+
+    await expectOneBroadcast(['section', 'item']);
+  });
+
+  it('includes catalog items when adding a list item can create or restore one', async () => {
+    const listRes = await agent(app)
+      .post('/lists')
+      .send({ storeId, name: 'Item side-effect list' })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app)
+      .post('/lists/items/add')
+      .send({ listId: listRes.body.id, name: 'New catalog item', sectionId, quantity: 1 })
+      .expect(201);
+
+    await expectOneBroadcast(['item', 'listItem']);
+  });
+
+  it('includes catalog items when completing a list updates purchase statistics', async () => {
+    const listRes = await agent(app)
+      .post('/lists')
+      .send({ storeId, name: 'Completion side-effect list' })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await agent(app)
+      .post('/lists/items/add')
+      .send({ listId: listRes.body.id, name: 'Purchased item', sectionId, quantity: 1 })
+      .expect(201);
+    await clearAfterBroadcast();
+
+    await db(app).listItem.updateMany({
+      where: { listId: listRes.body.id },
+      data: { isChecked: true },
+    });
+    await agent(app).post(`/lists/${listRes.body.id}/complete`).expect(201);
+
+    await expectOneBroadcast(['list', 'item', 'listItem']);
+  });
+});

--- a/apps/server/test/sync/sync.service.spec.ts
+++ b/apps/server/test/sync/sync.service.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SyncService } from '../../src/sync/sync.service';
+import type { SyncDeps } from '../../src/sync/sync-deps';
+import type { PrismaService } from '../../src/prisma.service';
+
+function createMockPrisma() {
+  return {
+    store: {
+      findMany: vi.fn().mockResolvedValue([{ id: 's1', householdId: 'h1' }]),
+      findFirst: vi.fn().mockResolvedValue({ id: 's1', householdId: 'h1' }),
+    },
+    household: {
+      findMany: vi.fn().mockResolvedValue([{ id: 'h1' }]),
+      findFirst: vi.fn().mockResolvedValue({ id: 'h1' }),
+    },
+    item: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 'it1' }),
+    },
+    list: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+function createOperationDeps(service: SyncService): SyncDeps {
+  return (service as unknown as { createDeps(): SyncDeps }).createDeps();
+}
+
+describe('SyncService access cache', () => {
+  let service: SyncService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    mockPrisma = createMockPrisma();
+    service = new SyncService(mockPrisma as unknown as PrismaService);
+  });
+
+  it('memoizes accessible store ids for the same user within one request', async () => {
+    const deps = createOperationDeps(service);
+
+    const p1 = deps.getAccessibleStoreIdsForSync('user-1');
+    const p2 = deps.getAccessibleStoreIdsForSync('user-1');
+
+    expect(p1).toBe(p2);
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(1);
+    await expect(p1).resolves.toEqual(['s1']);
+  });
+
+  it('memoizes accessible household ids for the same user within one request', async () => {
+    const deps = createOperationDeps(service);
+
+    const p1 = deps.getAccessibleHouseholdIdsForSync('user-1');
+    const p2 = deps.getAccessibleHouseholdIdsForSync('user-1');
+
+    expect(p1).toBe(p2);
+    expect(mockPrisma.household.findMany).toHaveBeenCalledTimes(1);
+    await expect(p1).resolves.toEqual(['h1']);
+  });
+
+  it('re-queries accessible store ids for a fresh pull operation', async () => {
+    await service.pull('item', null, 100, 'user-1');
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(1);
+
+    await service.pull('item', null, 100, 'user-1');
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-queries accessible store ids for a fresh push operation', async () => {
+    createOperationDeps(service).getAccessibleStoreIdsForSync('user-1');
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(1);
+
+    const result = await service.push(
+      'item',
+      [
+        {
+          newDocumentState: {
+            id: 'it1',
+            name: 'Milk',
+            storeId: 's1',
+            sectionId: 's1',
+            defaultUnit: 'piece',
+            _deleted: false,
+            updatedAt: new Date().toISOString(),
+          },
+          assumedMasterState: null,
+        },
+      ],
+      'user-1',
+    );
+    expect(result).toEqual([]);
+
+    createOperationDeps(service).getAccessibleStoreIdsForSync('user-1');
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps overlapping operation caches independent without evicting either one', async () => {
+    const firstOperation = createOperationDeps(service);
+    const secondOperation = createOperationDeps(service);
+
+    const firstRequest = firstOperation.getAccessibleStoreIdsForSync('user-1');
+    const secondRequest = secondOperation.getAccessibleStoreIdsForSync('user-1');
+    const repeatedFirstRequest = firstOperation.getAccessibleStoreIdsForSync('user-1');
+
+    expect(firstRequest).toBe(repeatedFirstRequest);
+    expect(firstRequest).not.toBe(secondRequest);
+    expect(mockPrisma.store.findMany).toHaveBeenCalledTimes(2);
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      ['s1'],
+      ['s1'],
+    ]);
+  });
+});

--- a/apps/web/src/core/rxdb/__tests__/sync-stream.test.ts
+++ b/apps/web/src/core/rxdb/__tests__/sync-stream.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Subject } from 'rxjs';
+import type { RxReplicationPullStreamItem } from 'rxdb';
+import { handleSyncChangedPayload, openSharedSyncStream, registerPullStream } from '../database';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type StreamItem = RxReplicationPullStreamItem<any, any>;
+
+function makeSubject(): Subject<StreamItem> {
+  const subject = new Subject<StreamItem>();
+  vi.spyOn(subject, 'next');
+  return subject;
+}
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  close = vi.fn();
+  onopen: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  private listeners = new Map<string, Array<(event: Event) => void>>();
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener = vi.fn((type: string, listener: (event: Event) => void) => {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  });
+
+  emit(type: string, event = new Event(type)) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+beforeEach(() => {
+  sessionStorage.setItem('__grocerun_test_token__', 'test-token');
+  FakeEventSource.instances = [];
+  globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('handleSyncChangedPayload', () => {
+  let listSubject: Subject<StreamItem>;
+  let storeSubject: Subject<StreamItem>;
+
+  beforeEach(() => {
+    listSubject = makeSubject();
+    storeSubject = makeSubject();
+    registerPullStream('list', listSubject);
+    registerPullStream('store', storeSubject);
+  });
+
+  it('routes SYNC_CHANGED collections to the matching pull stream only', () => {
+    handleSyncChangedPayload('{"collections":["list"]}');
+    expect(listSubject.next).toHaveBeenCalledWith('RESYNC');
+    expect(storeSubject.next).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts to all pull streams on malformed, empty or missing collections', () => {
+    handleSyncChangedPayload('not-json');
+    handleSyncChangedPayload('{"collections":[]}');
+    handleSyncChangedPayload('{"reason":"mutation"}');
+    expect(listSubject.next).toHaveBeenCalledTimes(3);
+    expect(storeSubject.next).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-registering a stream replaces the prior registration without affecting others', () => {
+    const firstList = makeSubject();
+    const secondList = makeSubject();
+    registerPullStream('list', firstList);
+    registerPullStream('list', secondList);
+    registerPullStream('store', storeSubject);
+
+    handleSyncChangedPayload('{"collections":["list"]}');
+    expect(secondList.next).toHaveBeenCalledWith('RESYNC');
+    expect(firstList.next).not.toHaveBeenCalled();
+    expect(storeSubject.next).not.toHaveBeenCalled();
+  });
+});
+
+describe('shared sync stream heartbeat', () => {
+  it('keeps an otherwise-idle healthy stream open when HEARTBEAT events arrive', async () => {
+    vi.useFakeTimers();
+
+    await openSharedSyncStream('/api/v1/sync/stream');
+    const source = FakeEventSource.instances.at(-1)!;
+    source.emit('open');
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    source.emit('HEARTBEAT');
+
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(source.close).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/core/rxdb/__tests__/sync-stream.test.ts
+++ b/apps/web/src/core/rxdb/__tests__/sync-stream.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Subject } from 'rxjs';
 import type { RxReplicationPullStreamItem } from 'rxdb';
 import { handleSyncChangedPayload, openSharedSyncStream, registerPullStream } from '../database';
+import { onDiagnostic } from '../../diagnostics/event-bus';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type StreamItem = RxReplicationPullStreamItem<any, any>;
+type StreamItem = RxReplicationPullStreamItem<
+  { id: string; updatedAt: string },
+  { id: string; updatedAt: string }
+>;
 
 function makeSubject(): Subject<StreamItem> {
   const subject = new Subject<StreamItem>();
@@ -65,12 +68,43 @@ describe('handleSyncChangedPayload', () => {
     expect(storeSubject.next).not.toHaveBeenCalled();
   });
 
-  it('broadcasts to all pull streams on malformed, empty or missing collections', () => {
+  it('broadcasts to all pull streams and emits an SSE error on malformed, empty or missing collections', () => {
+    const diagnostics: Array<{ type: string; state?: string }> = []
+    const unsubscribe = onDiagnostic((event) => diagnostics.push(event))
+
     handleSyncChangedPayload('not-json');
     handleSyncChangedPayload('{"collections":[]}');
     handleSyncChangedPayload('{"reason":"mutation"}');
     expect(listSubject.next).toHaveBeenCalledTimes(3);
     expect(storeSubject.next).toHaveBeenCalledTimes(3);
+    expect(diagnostics).toHaveLength(3)
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'sse', state: 'error' }),
+        expect.objectContaining({ type: 'sse', state: 'error' }),
+        expect.objectContaining({ type: 'sse', state: 'error' }),
+      ]),
+    )
+    unsubscribe()
+  });
+
+  it('broadcasts to all streams when a collection is unknown or has no registered stream', () => {
+    const diagnostics: Array<{ type: string; state?: string }> = []
+    const unsubscribe = onDiagnostic((event) => diagnostics.push(event))
+
+    handleSyncChangedPayload('{"collections":["unknown"]}');
+    handleSyncChangedPayload('{"collections":["section"]}');
+
+    expect(listSubject.next).toHaveBeenCalledTimes(2);
+    expect(storeSubject.next).toHaveBeenCalledTimes(2);
+    expect(diagnostics).toHaveLength(2)
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'sse', state: 'error' }),
+        expect.objectContaining({ type: 'sse', state: 'error' }),
+      ]),
+    )
+    unsubscribe()
   });
 
   it('re-registering a stream replaces the prior registration without affecting others', () => {

--- a/apps/web/src/core/rxdb/database.ts
+++ b/apps/web/src/core/rxdb/database.ts
@@ -373,7 +373,7 @@ function startPullReplication<DocType, Checkpoint extends { id: string; updatedA
   const { collection, basePath, replicationIdentifier, pullStream$, enablePush = false } = args
   const collectionName = basePath.split('/').pop() ?? basePath
 
-  registerPullStream(pullStream$)
+  registerPullStream(collectionName, pullStream$)
 
   const replicationState = replicateRxCollection<DocType, Checkpoint>({
     collection,
@@ -489,16 +489,17 @@ function getSyncStreamUrl(): string {
  * Reconnects automatically after 5 s if the connection drops.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
-const sharedPullStreams = new Set<Subject<RxReplicationPullStreamItem<any, any>>>()
+const sharedPullStreams = new Map<string, Subject<RxReplicationPullStreamItem<any, any>>>()
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
 const RESYNC_SIGNAL = 'RESYNC' as RxReplicationPullStreamItem<any, any>
 
 function registerPullStream<DocType, Checkpoint>(
+  collectionName: string,
   subject: Subject<RxReplicationPullStreamItem<DocType, Checkpoint>>,
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
-  sharedPullStreams.add(subject as Subject<RxReplicationPullStreamItem<any, any>>)
+  sharedPullStreams.set(collectionName, subject as Subject<RxReplicationPullStreamItem<any, any>>)
   if (!visibilityListenerAdded) {
     visibilityListenerAdded = true
     document.addEventListener('visibilitychange', () => {
@@ -506,8 +507,8 @@ function registerPullStream<DocType, Checkpoint>(
         // Tab regained visibility: reopen SSE if it was closed, and
         // trigger an immediate resync to catch up on missed changes.
         emitDiagnostic({ type: 'resync', source: 'visibility', at: Date.now() })
-        for (const stream of sharedPullStreams) {
-          stream.next(RESYNC_SIGNAL)
+        for (const subject of sharedPullStreams.values()) {
+          subject.next(RESYNC_SIGNAL)
         }
         if (!sharedSyncStreamOpened) {
           sharedSyncStreamOpened = true
@@ -536,8 +537,8 @@ function registerPullStream<DocType, Checkpoint>(
 
 function resyncAll() {
   emitDiagnostic({ type: 'resync', source: 'periodic', at: Date.now() })
-  for (const stream of sharedPullStreams) {
-    stream.next(RESYNC_SIGNAL)
+  for (const subject of sharedPullStreams.values()) {
+    subject.next(RESYNC_SIGNAL)
   }
 }
 
@@ -614,16 +615,39 @@ async function openSharedSyncStream(url: string, forceRefresh = false) {
   src.addEventListener('RESYNC', () => {
     resetWatchdog()
     emitDiagnostic({ type: 'resync', source: 'sse', at: Date.now() })
-    for (const subject of sharedPullStreams) {
+    for (const subject of sharedPullStreams.values()) {
       subject.next(RESYNC_SIGNAL)
     }
   })
 
-  src.addEventListener('SYNC_CHANGED', () => {
+  src.addEventListener('SYNC_CHANGED', (event) => {
     resetWatchdog()
     emitDiagnostic({ type: 'resync', source: 'sse', at: Date.now() })
-    for (const subject of sharedPullStreams) {
-      subject.next(RESYNC_SIGNAL)
+
+    // Parse the collections array from the event payload.
+    // Only resync the collections the server indicates changed.
+    let collections: string[] | undefined
+    try {
+      const raw = JSON.parse((event as MessageEvent).data)
+      if (raw && typeof raw === 'object' && Array.isArray(raw.collections)) {
+        collections = raw.collections.filter((c: unknown): c is string => typeof c === 'string')
+      }
+    } catch {
+      // Malformed payload — fall through to broadcast to all
+    }
+
+    if (collections && collections.length > 0) {
+      const collectionSet = new Set(collections)
+      for (const [name, subject] of sharedPullStreams) {
+        if (collectionSet.has(name)) {
+          subject.next(RESYNC_SIGNAL)
+        }
+      }
+    } else {
+      // Defensive fallback: if we can't parse collections, broadcast to all.
+      for (const subject of sharedPullStreams.values()) {
+        subject.next(RESYNC_SIGNAL)
+      }
     }
   })
 

--- a/apps/web/src/core/rxdb/database.ts
+++ b/apps/web/src/core/rxdb/database.ts
@@ -371,7 +371,7 @@ function startPullReplication<DocType, Checkpoint extends { id: string; updatedA
   enablePush?: boolean
 }) {
   const { collection, basePath, replicationIdentifier, pullStream$, enablePush = false } = args
-  const collectionName = basePath.split('/').pop() ?? basePath
+  const collectionName = getSyncCollectionName(basePath)
 
   registerPullStream(collectionName, pullStream$)
 
@@ -488,18 +488,40 @@ function getSyncStreamUrl(): string {
  *
  * Reconnects automatically after 5 s if the connection drops.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
-const sharedPullStreams = new Map<string, Subject<RxReplicationPullStreamItem<any, any>>>()
+export const SYNC_COLLECTION_NAMES = [
+  'section',
+  'item',
+  'list',
+  'listItem',
+  'store',
+  'household',
+] as const
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
-const RESYNC_SIGNAL = 'RESYNC' as RxReplicationPullStreamItem<any, any>
+export type SyncCollectionName = (typeof SYNC_COLLECTION_NAMES)[number]
+
+const syncCollectionNameSet = new Set<string>(SYNC_COLLECTION_NAMES)
+
+type RegisteredPullStream = {
+  resync: () => void
+}
+
+const sharedPullStreams = new Map<SyncCollectionName, RegisteredPullStream>()
+
+function getSyncCollectionName(basePath: string): SyncCollectionName {
+  const collectionName = basePath.split('/').pop() ?? basePath
+  if (!syncCollectionNameSet.has(collectionName)) {
+    throw new Error(`Unknown sync collection: ${collectionName}`)
+  }
+  return collectionName as SyncCollectionName
+}
 
 export function registerPullStream<DocType, Checkpoint>(
-  collectionName: string,
+  collectionName: SyncCollectionName,
   subject: Subject<RxReplicationPullStreamItem<DocType, Checkpoint>>,
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
-  sharedPullStreams.set(collectionName, subject as Subject<RxReplicationPullStreamItem<any, any>>)
+  sharedPullStreams.set(collectionName, {
+    resync: () => subject.next('RESYNC' as RxReplicationPullStreamItem<DocType, Checkpoint>),
+  })
   if (!visibilityListenerAdded) {
     visibilityListenerAdded = true
     document.addEventListener('visibilitychange', () => {
@@ -507,9 +529,7 @@ export function registerPullStream<DocType, Checkpoint>(
         // Tab regained visibility: reopen SSE if it was closed, and
         // trigger an immediate resync to catch up on missed changes.
         emitDiagnostic({ type: 'resync', source: 'visibility', at: Date.now() })
-        for (const subject of sharedPullStreams.values()) {
-          subject.next(RESYNC_SIGNAL)
-        }
+        resyncAllPullStreams()
         if (!sharedSyncStreamOpened) {
           sharedSyncStreamOpened = true
           void openSharedSyncStream(getSyncStreamUrl())
@@ -537,8 +557,12 @@ export function registerPullStream<DocType, Checkpoint>(
 
 function resyncAll() {
   emitDiagnostic({ type: 'resync', source: 'periodic', at: Date.now() })
-  for (const subject of sharedPullStreams.values()) {
-    subject.next(RESYNC_SIGNAL)
+  resyncAllPullStreams()
+}
+
+function resyncAllPullStreams() {
+  for (const stream of sharedPullStreams.values()) {
+    stream.resync()
   }
 }
 
@@ -560,31 +584,42 @@ function stopPeriodicResync() {
  * resynced; malformed or empty payloads fall back to broadcasting to all.
  */
 export function handleSyncChangedPayload(rawData: string) {
-  // Parse the collections array from the event payload.
-  // Only resync the collections the server indicates changed.
-  let collections: string[] | undefined
+  let collections: SyncCollectionName[] | null = null
   try {
-    const raw = JSON.parse(rawData)
-    if (raw && typeof raw === 'object' && Array.isArray(raw.collections)) {
-      collections = raw.collections.filter((c: unknown): c is string => typeof c === 'string')
-    }
-  } catch {
-    // Malformed payload — fall through to broadcast to all
-  }
-
-  if (collections && collections.length > 0) {
-    const collectionSet = new Set(collections)
-    for (const [name, subject] of sharedPullStreams) {
-      if (collectionSet.has(name)) {
-        subject.next(RESYNC_SIGNAL)
+    const raw: unknown = JSON.parse(rawData)
+    if (raw && typeof raw === 'object' && 'collections' in raw) {
+      const candidate = raw.collections
+      if (
+        Array.isArray(candidate)
+        && candidate.length > 0
+        && candidate.every((name): name is string => typeof name === 'string')
+        && candidate.every((name) => syncCollectionNameSet.has(name))
+      ) {
+        collections = [...new Set(candidate)] as SyncCollectionName[]
       }
     }
-  } else {
-    // Defensive fallback: if we can't parse collections, broadcast to all.
-    for (const subject of sharedPullStreams.values()) {
-      subject.next(RESYNC_SIGNAL)
-    }
+  } catch {
+    // The diagnostic and fallback below preserve convergence on bad payloads.
   }
+
+  const matchingStreams = collections
+    ? collections
+      .map((collectionName) => sharedPullStreams.get(collectionName))
+      .filter((stream): stream is RegisteredPullStream => stream !== undefined)
+    : []
+
+  if (matchingStreams.length > 0) {
+    for (const stream of matchingStreams) {
+      stream.resync()
+    }
+    return
+  }
+
+  // A malformed, unknown, empty, or currently unregistered collection must
+  // never leave a client stale. Report it through the existing SSE state and
+  // use the conservative all-stream resync fallback.
+  emitDiagnostic({ type: 'sse', state: 'error', at: Date.now() })
+  resyncAllPullStreams()
 }
 
 export async function openSharedSyncStream(url: string, forceRefresh = false) {
@@ -652,9 +687,7 @@ export async function openSharedSyncStream(url: string, forceRefresh = false) {
   src.addEventListener('RESYNC', () => {
     resetWatchdog()
     emitDiagnostic({ type: 'resync', source: 'sse', at: Date.now() })
-    for (const subject of sharedPullStreams.values()) {
-      subject.next(RESYNC_SIGNAL)
-    }
+    resyncAllPullStreams()
   })
 
   src.addEventListener('SYNC_CHANGED', (event) => {

--- a/apps/web/src/core/rxdb/database.ts
+++ b/apps/web/src/core/rxdb/database.ts
@@ -494,7 +494,7 @@ const sharedPullStreams = new Map<string, Subject<RxReplicationPullStreamItem<an
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RxDB pull stream generics are untyped
 const RESYNC_SIGNAL = 'RESYNC' as RxReplicationPullStreamItem<any, any>
 
-function registerPullStream<DocType, Checkpoint>(
+export function registerPullStream<DocType, Checkpoint>(
   collectionName: string,
   subject: Subject<RxReplicationPullStreamItem<DocType, Checkpoint>>,
 ) {
@@ -554,7 +554,40 @@ function stopPeriodicResync() {
   }
 }
 
-async function openSharedSyncStream(url: string, forceRefresh = false) {
+/**
+ * Parses a SYNC_CHANGED SSE payload and routes RESYNC signals to the
+ * affected pull streams. Only the collections named in `collections` are
+ * resynced; malformed or empty payloads fall back to broadcasting to all.
+ */
+export function handleSyncChangedPayload(rawData: string) {
+  // Parse the collections array from the event payload.
+  // Only resync the collections the server indicates changed.
+  let collections: string[] | undefined
+  try {
+    const raw = JSON.parse(rawData)
+    if (raw && typeof raw === 'object' && Array.isArray(raw.collections)) {
+      collections = raw.collections.filter((c: unknown): c is string => typeof c === 'string')
+    }
+  } catch {
+    // Malformed payload — fall through to broadcast to all
+  }
+
+  if (collections && collections.length > 0) {
+    const collectionSet = new Set(collections)
+    for (const [name, subject] of sharedPullStreams) {
+      if (collectionSet.has(name)) {
+        subject.next(RESYNC_SIGNAL)
+      }
+    }
+  } else {
+    // Defensive fallback: if we can't parse collections, broadcast to all.
+    for (const subject of sharedPullStreams.values()) {
+      subject.next(RESYNC_SIGNAL)
+    }
+  }
+}
+
+export async function openSharedSyncStream(url: string, forceRefresh = false) {
   const token = forceRefresh ? await refreshAndGetToken() : await getAccessToken()
   // EventSource doesn't support custom headers — token is appended as a
   // query param. The server only accepts query-token auth on SSE endpoints.
@@ -612,6 +645,10 @@ async function openSharedSyncStream(url: string, forceRefresh = false) {
     resetWatchdog()
   })
 
+  src.addEventListener('HEARTBEAT', () => {
+    resetWatchdog()
+  })
+
   src.addEventListener('RESYNC', () => {
     resetWatchdog()
     emitDiagnostic({ type: 'resync', source: 'sse', at: Date.now() })
@@ -623,32 +660,7 @@ async function openSharedSyncStream(url: string, forceRefresh = false) {
   src.addEventListener('SYNC_CHANGED', (event) => {
     resetWatchdog()
     emitDiagnostic({ type: 'resync', source: 'sse', at: Date.now() })
-
-    // Parse the collections array from the event payload.
-    // Only resync the collections the server indicates changed.
-    let collections: string[] | undefined
-    try {
-      const raw = JSON.parse((event as MessageEvent).data)
-      if (raw && typeof raw === 'object' && Array.isArray(raw.collections)) {
-        collections = raw.collections.filter((c: unknown): c is string => typeof c === 'string')
-      }
-    } catch {
-      // Malformed payload — fall through to broadcast to all
-    }
-
-    if (collections && collections.length > 0) {
-      const collectionSet = new Set(collections)
-      for (const [name, subject] of sharedPullStreams) {
-        if (collectionSet.has(name)) {
-          subject.next(RESYNC_SIGNAL)
-        }
-      }
-    } else {
-      // Defensive fallback: if we can't parse collections, broadcast to all.
-      for (const subject of sharedPullStreams.values()) {
-        subject.next(RESYNC_SIGNAL)
-      }
-    }
+    handleSyncChangedPayload((event as MessageEvent).data)
   })
 
   src.addEventListener('HOUSEHOLD_REMOVED', (event) => {

--- a/apps/web/src/features/lists/hooks/useLists.ts
+++ b/apps/web/src/features/lists/hooks/useLists.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@/core/lib/useMutation"
 import { useRxMutation } from "@/core/lib/useRxMutation"
 import { api } from "@/core/lib/api"
-import { resyncListItems, resyncLists } from "@/core/rxdb"
+import { resyncItems, resyncListItems, resyncLists } from "@/core/rxdb"
 import { getRxDb } from "@/core/rxdb"
 import type { ListDocType } from "@/core/rxdb"
 import { networkAwareErrorToast } from "@/core/lib/error-toast"
@@ -142,6 +142,7 @@ export function useCompleteList() {
     onSuccess: () => {
       resyncLists()
       resyncListItems()
+      resyncItems()
     },
     onError: (error) => {
       networkAwareErrorToast(error, "Failed to complete trip")

--- a/apps/web/src/features/stores/hooks/useSections.ts
+++ b/apps/web/src/features/stores/hooks/useSections.ts
@@ -19,7 +19,7 @@
 import { useRxQuery } from "@/core/lib/useRxQuery"
 import { useMutation } from '@/core/lib/useMutation'
 import { api } from '@/core/lib/api'
-import { resyncSections } from '@/core/rxdb'
+import { resyncItems, resyncSections } from '@/core/rxdb'
 import { toast } from 'sonner'
 
 // ----- Types -----
@@ -104,6 +104,7 @@ export function useDeleteSection(_storeId: string) {
     mutationFn: (id: string) => api.delete(`/sections/${id}`),
     onSuccess: () => {
       resyncSections()
+      resyncItems()
       toast.success('Section deleted')
     },
     onError: () => {

--- a/apps/web/src/features/stores/hooks/useStore.ts
+++ b/apps/web/src/features/stores/hooks/useStore.ts
@@ -1,7 +1,7 @@
 import { useRxQuery } from "@/core/lib/useRxQuery"
 import { useMutation } from "@/core/lib/useMutation"
 import { api } from "@/core/lib/api"
-import { resyncStores } from "@/core/rxdb"
+import { resyncItems, resyncListItems, resyncLists, resyncSections, resyncStores } from "@/core/rxdb"
 import { toast } from "sonner"
 import { z } from "zod"
 
@@ -74,6 +74,10 @@ export function useDeleteStore(storeId: string, options?: { onSuccess?: () => vo
     mutationFn: () => api.delete(`/stores/${storeId}`),
     onSuccess: () => {
       resyncStores()
+      resyncSections()
+      resyncItems()
+      resyncLists()
+      resyncListItems()
       toast.success("Store deleted")
       options?.onSuccess?.()
     },

--- a/planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md
+++ b/planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md
@@ -1,0 +1,324 @@
+# Brainstorm: SSE Sync Collection Split Analysis
+
+**Date:** 2026-07-10T0000
+**Status:** analysis complete, awaiting user comments
+**Source:** Oracle pre-implementation review for GROCERUN-32 (notification data model)
+**Trigger:** Architectural question — is the current 6-collection sync split optimal, or should collections be consolidated?
+
+---
+
+## Oracle Report (Verbatim)
+
+### Current Split Assessment
+
+**The collection split is architecturally correct. The transport layer is not.**
+
+#### What works
+
+The 6-collection split correctly aligns with two orthogonal axes: **access scope** and **lifecycle/mutation pattern**.
+
+| Collection | Access scope | Lifecycle | Push? |
+|-----------|-------------|-----------|-------|
+| `household` | `userId → householdIds` (direct membership) | Rare admin changes | No |
+| `store` | `userId → householdIds → stores` | Rare admin changes | No |
+| `section` | `userId → householdIds → stores → sections` | Rare + bulk reorder | No |
+| `list` | `userId → householdIds → stores → lists` | State machine (PLANNING→SHOPPING→COMPLETED) | No |
+| `item` | `userId → householdIds → stores → items` | High-frequency during shopping | **Yes** |
+| `listItem` | `userId → householdIds → stores → lists → listItems` | Highest-frequency (toggle, qty) | **Yes** |
+
+The local-first vs. server-authoritative split (ADR-007 Decision 3) is the right cut. Items and listItems are the only collections where offline writes matter during shopping. Everything else is configuration/admin data that goes through REST. Merging a push-enabled collection with a pull-only one would be architecturally incoherent.
+
+#### What doesn't work (but it's not the split's fault)
+
+**1. SSE routing is not actually collection-scoped — despite the protocol doc claiming it is.**
+
+The protocol doc (`rxdb-sync-protocol.md:397-398`) states:
+> SSE fan-out is collection-scoped: The `SYNC_CHANGED` event includes a `collections` array. The client only emits `'RESYNC'` into the pull Subjects for the affected collections.
+
+But the actual code (`database.ts:622-628`) does **not** parse the `collections` array:
+
+```typescript
+src.addEventListener('SYNC_CHANGED', () => {  // ← no event param used
+    resetWatchdog()
+    for (const subject of sharedPullStreams) {  // ← Set, not Map
+      subject.next(RESYNC_SIGNAL)              // ← broadcasts to ALL 6 streams
+    }
+})
+```
+
+`sharedPullStreams` is a `Set<Subject>` — there's no way to route to a specific collection. The server already sends `{ collections: ['store'] }` in the payload, but the client throws it away. This is the root cause of the overfetch problem documented in `sync-overfetch-analyze.md`: a single listItem toggle generates 1 push + 6 pulls = 7 requests, when it should be 1 push + 1 pull.
+
+**2. Access query redundancy is real but minor.**
+
+Five collections (`store`, `section`, `list`, `item`, `listItem`) each call `getAccessibleStoreIdsForSync(userId)` on every pull batch. That's 5 Prisma queries doing the same household→store join. But with batch sizes of 50-100, the access query is ~1% of the pull cost. Not worth consolidating collections to fix — a simple per-request memo cache on `SyncDeps` would eliminate it without touching the collection structure.
+
+**3. Initial load makes 6 sequential HTTP requests.**
+
+On `resyncAll()`, all 6 pull streams emit `RESYNC` simultaneously. RxDB fires 6 parallel HTTP requests. This is 6 round-trips on cold start. For a household with 3 stores × 10 sections × 50 items × 5 lists × 20 listItems, this is 6 requests totaling maybe 200KB. Not great, but not a real bottleneck — it happens once per session and resolves in parallel.
+
+#### What the split does NOT cause
+
+- **Checkpoint independence is a feature, not a bug.** A section reorder (`reorderSections`) advances only the section checkpoint. Stores, items, and lists are untouched. If sections were nested in stores, a reorder would advance the store checkpoint, forcing clients to re-pull store documents that didn't change.
+- **Tombstone isolation is a feature.** A deleted section's tombstone is delivered through the section pull only. It doesn't pollute the store pull response.
+- **SSE granularity is a feature.** The server can say "only `section` changed" and (once routing is fixed) only sections get re-pulled. Nesting would force coarser notifications.
+
+---
+
+### Consolidation Options
+
+#### Option A: Fold sections into stores (nested pull, separate RxDB collections)
+
+**What**: `GET /sync/store/pull` returns store documents with embedded `sections[]`. Client pull handler writes stores to `stores` collection and sections to `sections` collection.
+
+**Trade-offs:**
+- **Pro**: Eliminates 1 HTTP round-trip on initial load and on store/section changes (5 collections → 4).
+- **Pro**: Section access is implicitly derived from store access — no separate `getAccessibleStoreIdsForSync` call for sections.
+- **Con**: Breaks RxDB's `replicateRxCollection` model. The store pull handler would need to write to two collections, which is not how `replicateRxCollection` works. You'd need a custom replication wrapper or a "virtual" store collection that fans out to sections.
+- **Con**: Checkpoint coupling. A section reorder advances the store checkpoint. Next pull returns the store (unchanged) + all sections. The store payload is wasted bandwidth.
+- **Con**: SSE routing becomes ambiguous. When a section changes, do you send `['store']` (which includes sections) or `['section']`? If `['store']`, then section-only changes trigger store re-pulls for any client not using the nested endpoint.
+- **Con**: Tombstone delivery for sections must go through the store pull. A deleted section's tombstone is embedded in the store response, which means the client must diff the sections array to find tombstones — losing RxDB's native tombstone handling.
+- **Effort**: High. Custom replication logic, checkpoint redesign, SSE routing changes, tombstone handling rewrite.
+
+**Verdict**: Not worth it. The benefit (1 fewer round-trip) is dwarfed by the complexity of breaking RxDB's per-collection replication model.
+
+#### Option B: Fold stores into households
+
+**What**: `GET /sync/household/pull` returns household documents with embedded `stores[]` (and potentially their sections).
+
+**Trade-offs:**
+- **Pro**: Eliminates 2 round-trips on initial load (4 collections → 2).
+- **Con**: Massive over-fetching. A household with 5 stores, each with 20 sections, produces a huge document. Any store change re-pulls the entire household payload.
+- **Con**: Checkpoint coupling at the highest level. Any store or section change advances the household checkpoint, forcing all household members to re-pull the entire household tree.
+- **Con**: The user explicitly flagged this as the over-anchoring extreme.
+- **Con**: Household mutations (member join/leave, ownership transfer) would advance the checkpoint and force re-pulling all stores.
+- **Effort**: High, and wrong direction.
+
+**Verdict**: Rejected. This is the over-anchoring extreme the user correctly wants to avoid.
+
+#### Option C: Bundle pull endpoints (multi-collection pull)
+
+**What**: Server exposes `GET /sync/pull?collections=store,section&updatedAt=...&id=...` that returns results for multiple collections in one response. Client still has 6 RxDB collections with 6 replications, but the pull handler batches requests.
+
+**Trade-offs:**
+- **Pro**: Reduces HTTP round-trips from 6 to 1-2 on initial load and on SSE-triggered resyncs.
+- **Pro**: Keeps RxDB's per-collection replication model intact (each collection still has its own checkpoint).
+- **Con**: Major refactor of the pull handler. Each collection's `replicateRxCollection` pull handler would need to coordinate with others to batch requests. RxDB doesn't natively support merged-stream replication.
+- **Con**: Checkpoint management becomes complex — the bundled endpoint needs to handle different checkpoints per collection and return per-collection checkpoints.
+- **Con**: Error handling is coupled — if one collection's pull fails, do you fail the entire batch?
+- **Effort**: High. This is the most invasive option.
+
+**Verdict**: Evaluate for Phase 5+ if round-trip count becomes a measured bottleneck. Not justified now — the real problem is SSE routing, not collection count.
+
+#### Option D: Keep split, fix transport layer (recommended)
+
+**What**: Keep 6 collections as-is. Fix the two transport-layer problems:
+1. **Scope SSE routing**: Change `sharedPullStreams` from `Set<Subject>` to `Map<string, Subject>`. Parse `event.data.collections` in the `SYNC_CHANGED` handler and only emit `RESYNC` to matching streams.
+2. **Skip self-notify**: Server excludes the originating user from `notifyChanged` for push-triggered SSE (their local state is already correct from the optimistic write).
+
+**Trade-offs:**
+- **Pro**: Minimal change, immediate impact. A listItem toggle goes from 1 push + 6 pulls = 7 requests to 1 push + 0 pulls (self) or 1 push + 1 pull (other clients).
+- **Pro**: No collection structure changes, no checkpoint coupling, no RxDB abstraction breakage.
+- **Pro**: The server already sends `{ collections: ['listItem'] }` — the client just needs to read it.
+- **Con**: Doesn't reduce initial-load round-trips (still 6 parallel requests on cold start).
+- **Con**: Still 6 independent replications with 6 checkpoints to manage.
+- **Effort**: Low. ~50 lines of client code (Map instead of Set, parse event data). ~10 lines of server code (exclude pusher from notifyChanged).
+
+**Verdict**: This is the clear winner. It addresses the actual measured problem (overfetch) without touching the collection architecture.
+
+---
+
+### Recommendation
+
+**Keep the 6-collection split as-is. Add notification as a 7th collection. Fix the SSE routing.**
+
+#### Reasoning
+
+1. **The collection split is not the problem.** The split correctly separates entities by access scope and lifecycle. Sections have independent lifecycles from stores (bulk reorder is a distinct operation). Stores have independent lifecycles from households (store mutations don't cascade to household membership). Items and listItems are correctly split from each other (items are per-store metadata; listItems are per-list instances with shopping lock semantics).
+
+2. **The actual problem is transport inefficiency.** The `sync-overfetch-analyze.md` ticket correctly identifies that a single listItem toggle generates 7 HTTP requests. But the root cause is the client ignoring the `collections` array in `SYNC_CHANGED` events, not the number of collections. Fixing SSE routing (Option D) reduces this to 1-2 requests with minimal code change.
+
+3. **Consolidation would trade a minor, fixable inefficiency for permanent architectural complexity.** Folding sections into stores breaks RxDB's `replicateRxCollection` model, couples checkpoints between unrelated lifecycles, and complicates tombstone handling. The benefit (1 fewer round-trip) is negligible compared to the cost.
+
+4. **The access query redundancy is fixable without consolidation.** A per-request memo cache on `SyncDeps.getAccessibleStoreIdsForSync` (keyed by `userId`) would eliminate the 5 redundant Prisma queries during a `resyncAll()` without touching collection structure.
+
+5. **Initial-load round-trips are not a measured bottleneck.** 6 parallel HTTP requests on cold start, each returning 50-100 small JSON documents, resolves in a single RTT window. The steady-state cost (SSE-triggered resyncs) is far more impactful because it happens on every mutation.
+
+#### Concrete action items (ordered by impact/effort ratio)
+
+1. **Fix SSE routing** — Change `sharedPullStreams` from `Set<Subject>` to `Map<string, Subject>`. Parse `event.data.collections` in `SYNC_CHANGED` handler. Only emit `RESYNC` to matching streams. (~50 lines, `database.ts`)
+2. **Skip self-notify on push** — Thread pusher's `userId` to `SseBroadcastService.notifyChanged` and exclude it. (~10 lines, `sync.service.ts` + `sse-broadcast.service.ts`)
+3. **Memoize access queries** — Cache `getAccessibleStoreIdsForSync` / `getAccessibleHouseholdIdsForSync` per-request (or with a 5-second TTL) so 5 collections don't each make the same Prisma query. (~15 lines, `sync.service.ts`)
+4. **Update the protocol doc** — The doc claims collection-scoped SSE routing, but the code doesn't implement it. Either implement it (step 1) or fix the doc. Currently the doc is misleading.
+
+---
+
+### Impact on Notification Collection
+
+**The notification collection (GROCERUN-32) reinforces the principle that collections should be split by access scope, not by entity hierarchy.**
+
+Notifications are **user-scoped**, not household-scoped:
+- Access filter: `userId = currentUser` (not `householdId IN accessibleHouseholdIds`)
+- Lifecycle: created by server on mutations, never pushed by client
+- No relationship to the household→store→section/item/list→listItem hierarchy
+
+This means:
+1. **Notifications must be a separate collection.** They can't be folded into any household-scoped collection because their access scope is different. A user's notifications span multiple households.
+2. **Notification SSE routing must be scoped.** When a notification is created, the SSE event should include `['notification']` in the collections array. Once SSE routing is fixed (action item 1 above), only the notification collection gets re-pulled — not all 7 collections.
+3. **Notification pull should NOT call `getAccessibleStoreIdsForSync`.** Its access filter is `userId = currentUser`, which is a direct Prisma query on the Notification table. This is simpler and faster than the household-derived access checks.
+4. **The notification collection is pull-only** (server-authoritative per ADR-007 criteria 2 and 3). This aligns with household/store/section/list, not with item/listItem.
+
+**The notification collection does not change the analysis.** It's a natural 7th collection that follows the same pull-only pattern as the existing server-authoritative collections. The only design consideration is ensuring the SSE routing fix (action item 1) is in place before or alongside the notification collection, so that notification creation doesn't trigger re-pulls of all 6 existing collections.
+
+#### One caveat for notifications
+
+The `notification-data-model-analysis.md` proposes that `UserNotificationService.createForHousehold()` calls `sseBroadcast.notifyChanged(memberIds, { collections: ['notification'], reason: 'notification_created' })`. This is correct — but only if the client actually scopes the resync to `['notification']`. Without the SSE routing fix, creating a notification would trigger 7 pulls (6 existing + 1 notification), which is exactly the overfetch problem. **The SSE routing fix is a prerequisite for the notification collection to be efficient.**
+
+---
+
+## Orchestrator Addendum: Embedding Sections into Stores
+
+### Oracle's "Breaks replicateRxCollection" Claim — Clarified
+
+The oracle's claim that folding sections into stores "breaks RxDB's `replicateRxCollection` model" was about **one specific approach**: separate RxDB collections with a nested pull endpoint (store pull returns stores with embedded `sections[]`, pull handler writes to both `stores` and `sections` RxDB collections). That approach *does* break the model — `replicateRxCollection` expects one collection per replication stream, one checkpoint, one set of conflict resolution.
+
+But there's a simpler approach the oracle didn't consider:
+
+**Embed sections as an array on the store RxDB document.** No separate sections collection at all.
+
+```
+Store document = {
+  id, name, householdId, updatedAt,
+  sections: [{ id, name, sortOrder, deleted }]
+}
+```
+
+This works naturally with `replicateRxCollection`:
+- One collection, one checkpoint, one pull endpoint
+- When a section changes, bump the store's `updatedAt` (cascade)
+- Deleted sections: remove from the array (or mark `deleted: true` in the array)
+- No dual-write, no broken abstraction
+
+### Why They're Separate Now
+
+Historical: each Prisma model got its own sync collection. The pattern was "one model = one sync collection = one RxDB collection = one checkpoint." No one evaluated whether store+section should be one collection — they followed the pattern. A store is thin (`id, name, householdId` + timestamps). Sections are the meaningful children. There's no structural reason they must be separate.
+
+### Trade-offs of Embedding
+
+| | Separate (current) | Embedded |
+|---|---|---|
+| Section reorder | Re-pulls only changed sections | Re-pulls entire store doc (all sections) |
+| Checkpoint independence | Section checkpoint advances independently | Store checkpoint advances (sections are sub-docs) |
+| Tombstone handling | Native RxDB per-section tombstones | Manual — remove from array or mark deleted |
+| Payload size | Section pull returns only sections | Store pull returns store + all sections |
+| Collection count | 6 | 5 |
+| Complexity | Standard pattern | Need cascade timestamp update on section mutations |
+
+For a store with 5-20 sections, the payload difference is negligible. The checkpoint coupling means a section reorder forces a re-pull of the store document too — but that's one tiny document.
+
+### What Gets Simpler with Embedding
+
+- One fewer sync collection (pull handler, sync doc converter, checkpoint, `startXReplication`/`resyncX` function)
+- One fewer RxDB collection (schema, doc type, replication wiring)
+- Section access is free — comes with store access, no separate `getAccessibleStoreIdsForSync` call
+- One fewer SSE routing target
+- Adding notification later makes 6 collections instead of 7
+
+### What Gets More Complex
+
+- Section mutations (create, reorder, rename, delete) must cascade-update the parent store's `updatedAt` — otherwise sync doesn't pick them up
+- Sync doc converter must join sections into the store document (Prisma `include: { sections: true }`)
+- Section "tombstones" are manual — remove from array or mark `deleted: true` in the array, not native RxDB tombstones
+- Client queries change from `sectionsCollection.find()` to `storesCollection.findOne().sections`
+
+The cascade timestamp update is the main new complexity: any section mutation does `prisma.store.update({ where: { id: storeId }, data: { updatedAt: new Date() } })` after the section change. One line per mutation site.
+
+### Net Assessment
+
+Fewer moving parts, fewer concepts, fewer endpoints — but slightly more work at each mutation site. For a system that's growing (notifications coming next, more features after), fewer collections is a structural simplification that compounds.
+
+The refactor touches: sections service, sync layer, RxDB schema, and client reads. Non-trivial but cleaner to do before adding a 7th collection than after.
+
+### Other Consolidation Opportunities to Explore
+
+#### Systematic Fold Analysis
+
+Constraints: **access scope** (must match), **push/pull** (must match), and **parent-child** (must nest naturally).
+
+| Fold | Access scope match? | Push/pull match? | Parent-child? | Viable? |
+|------|---------------------|-------------------|---------------|---------|
+| Sections → Stores | ✓ (both household→store) | ✓ (both pull-only) | ✓ (section is child of store) | **Yes** |
+| Stores → Households | ✓ (both household-scoped) | ✓ (both pull-only) | ✓ (store is child of household) | **Maybe** |
+| Lists → Stores | ✓ (both household→store) | ✓ (both pull-only) | ✓ (list is child of store) | **Yes** |
+| Items → Stores | ✓ | ✗ (items push, stores pull) | ✓ | **No** |
+| ListItems → Lists | ✓ | ✗ (listItems push, lists pull) | ✓ | **No** |
+| Items ↔ ListItems | ✓ (both push) | ✓ | ✗ (different parents, different fields) | **No** |
+| Notifications → anything | ✗ (user-scoped) | — | — | **No** |
+
+#### Fold 1: Sections → Stores (already analyzed above)
+
+- **Collections:** 6 → 5
+- **Payload:** Store doc includes all sections. For 5-20 sections per store, negligible.
+- **Checkpoint coupling:** Section mutation bumps store `updatedAt`. Re-pulls store doc (thin + sections).
+- **New complexity:** Cascade timestamp on section mutations. Manual section tombstones (array removal).
+- **Simplification:** One fewer collection, sync handler, RxDB schema, replication function, SSE target.
+- **Lifecycle cost:** Low — sections are admin-style mutations (create, reorder, rename). Coupling to store is cheap.
+
+#### Fold 2: Lists → Stores
+
+Store document: `{ id, name, householdId, updatedAt, sections: [...], lists: [{ id, name, state, ... }] }`
+
+- **Collections:** 6 → 5 (or 4 if combined with Fold 1)
+- **Payload:** Store doc now includes lists too. A store might have 5-20 lists. Still manageable.
+- **Checkpoint coupling:** List state change (PLANNING→SHOPPING→COMPLETED) bumps store `updatedAt`. This means a shopping state transition forces re-pull of all sections and all other lists for that store.
+- **New complexity:** Cascade timestamp on list mutations (create, complete, delete, rename). Manual list tombstones.
+- **Lifecycle concern:** Lists are more dynamic than sections. A list state machine transition is a user-facing event that happens during active shopping. Coupling it to the store checkpoint means every list state change re-pulls the entire store document including all sections and all other lists. For a store with 20 lists and 20 sections, that's a bigger payload on every list interaction.
+- **Simplification:** One fewer collection, sync handler, RxDB schema, replication function, SSE target.
+
+#### Fold 3: Stores → Households
+
+Household document: `{ id, name, ownerId, members, updatedAt, stores: [{ id, name, sections: [...], lists: [...] }] }`
+
+- **Collections:** 6 → 3 (household absorbs stores, sections, lists; items and listItems remain)
+- **Payload:** Household doc includes all stores, all sections, all lists. For 3 stores × 15 sections × 10 lists = ~450 sub-documents. Getting heavy.
+- **Checkpoint coupling:** ANY store, section, or list mutation bumps household `updatedAt`. Full re-pull of the entire household tree. This is the over-anchoring extreme.
+- **Member change impact:** Household membership change (member join/leave) bumps `updatedAt`, forcing all remaining members to re-pull all stores, sections, and lists — even though none of that data changed.
+- **New complexity:** Cascade timestamp from section→store→household and list→store→household. Two levels of cascade.
+- **Simplification:** Three fewer collections, sync handlers, RxDB schemas, replication functions, SSE targets.
+
+#### Compound Options
+
+| Option | Folds | Collections | Notable trade-off |
+|--------|-------|-------------|-------------------|
+| **A** | Sections → Stores | 5 | Section mutation re-pulls store (thin) |
+| **B** | Lists → Stores | 5 | List state change re-pulls store (medium) |
+| **C** | Sections + Lists → Stores | 4 | Both above, combined |
+| **D** | Sections + Lists → Stores → Households | 3 | Everything couples to household checkpoint |
+| **E** | Stores → Households only (no section/list fold) | 5 | Store change re-pulls household (thin, but member changes too) |
+
+#### The Real Question: Lifecycle Coupling
+
+The access scope and push/pull constraints eliminate most folds. The remaining decision is purely about **lifecycle coupling** — how much checkpoint coupling are you willing to accept in exchange for fewer collections?
+
+- **Sections** are low-frequency, admin-style mutations (create, reorder, rename). Coupling to store is cheap.
+- **Lists** have a state machine that transitions during active shopping. Coupling to store means every list interaction re-pulls all sections and other lists for that store. More expensive.
+- **Stores → Households** couples everything to the household checkpoint, including membership changes. This is the extreme.
+
+#### Tentative Conclusion
+
+**Fold sections into stores (low lifecycle cost), keep lists separate (state machine is too active), keep stores separate from households (membership changes shouldn't cascade).**
+
+That gives 5 collections: household, store (with embedded sections), list, item, listItem — plus notification as 6th.
+
+This fold is deferred to a separate refactor ticket. The notification implementation plan proceeds with the current 6-collection structure plus SSE transport fixes.
+
+---
+
+## User Comments
+
+(To be added by user)
+
+---
+
+## Promotion Decision
+
+(To be decided after user comments)

--- a/planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md
+++ b/planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md
@@ -113,15 +113,15 @@ On `resyncAll()`, all 6 pull streams emit `RESYNC` simultaneously. RxDB fires 6 
 
 **What**: Keep 6 collections as-is. Fix the two transport-layer problems:
 1. **Scope SSE routing**: Change `sharedPullStreams` from `Set<Subject>` to `Map<string, Subject>`. Parse `event.data.collections` in the `SYNC_CHANGED` handler and only emit `RESYNC` to matching streams.
-2. **Skip self-notify**: Server excludes the originating user from `notifyChanged` for push-triggered SSE (their local state is already correct from the optimistic write).
+2. **Superseded — skip self-notify**: The initial proposal excluded the originating user. The implemented protocol deliberately notifies every connection for that user so other tabs/devices converge and the originating client pulls any canonical server-side fields.
 
 **Trade-offs:**
-- **Pro**: Minimal change, immediate impact. A listItem toggle goes from 1 push + 6 pulls = 7 requests to 1 push + 0 pulls (self) or 1 push + 1 pull (other clients).
+- **Pro**: Minimal change, immediate impact. A listItem toggle goes from 1 push + 6 pulls = 7 requests to 1 push + 1 collection-scoped pull per connected client.
 - **Pro**: No collection structure changes, no checkpoint coupling, no RxDB abstraction breakage.
 - **Pro**: The server already sends `{ collections: ['listItem'] }` — the client just needs to read it.
 - **Con**: Doesn't reduce initial-load round-trips (still 6 parallel requests on cold start).
 - **Con**: Still 6 independent replications with 6 checkpoints to manage.
-- **Effort**: Low. ~50 lines of client code (Map instead of Set, parse event data). ~10 lines of server code (exclude pusher from notifyChanged).
+- **Effort**: Low. Collection routing plus full fan-out to same-user connections.
 
 **Verdict**: This is the clear winner. It addresses the actual measured problem (overfetch) without touching the collection architecture.
 
@@ -146,7 +146,7 @@ On `resyncAll()`, all 6 pull streams emit `RESYNC` simultaneously. RxDB fires 6 
 #### Concrete action items (ordered by impact/effort ratio)
 
 1. **Fix SSE routing** — Change `sharedPullStreams` from `Set<Subject>` to `Map<string, Subject>`. Parse `event.data.collections` in `SYNC_CHANGED` handler. Only emit `RESYNC` to matching streams. (~50 lines, `database.ts`)
-2. **Skip self-notify on push** — Thread pusher's `userId` to `SseBroadcastService.notifyChanged` and exclude it. (~10 lines, `sync.service.ts` + `sse-broadcast.service.ts`)
+2. **Superseded — skip self-notify on push** — Rejected after implementation review. User-level exclusion would suppress other tabs/devices and can miss server-canonical fields; retain collection-scoped fan-out instead.
 3. **Memoize access queries** — Cache `getAccessibleStoreIdsForSync` / `getAccessibleHouseholdIdsForSync` per-request (or with a 5-second TTL) so 5 collections don't each make the same Prisma query. (~15 lines, `sync.service.ts`)
 4. **Update the protocol doc** — The doc claims collection-scoped SSE routing, but the code doesn't implement it. Either implement it (step 1) or fix the doc. Currently the doc is misleading.
 
@@ -185,7 +185,7 @@ But there's a simpler approach the oracle didn't consider:
 
 **Embed sections as an array on the store RxDB document.** No separate sections collection at all.
 
-```
+```typescript
 Store document = {
   id, name, householdId, updatedAt,
   sections: [{ id, name, sortOrder, deleted }]

--- a/planning/reviews/2026-08-04_review_fix-sse-transport-overfetch.md
+++ b/planning/reviews/2026-08-04_review_fix-sse-transport-overfetch.md
@@ -1,0 +1,151 @@
+# Review: fix/sse-transport-overfetch
+
+## Summary
+
+The branch correctly introduces collection-aware client routing, access-query memoization,
+and a single NestJS `SseBroadcastService` instance. However, the broader audit found three
+high-severity correctness regressions: push self-exclusion suppresses reconciliation and
+all other same-user sessions, REST broadcast manifests omit collections actually changed
+by cascades or side effects, and the client watchdog cannot observe the server's comment
+heartbeats. These can leave clients stale or force a healthy SSE connection to reconnect
+continuously. **Verdict: Request Changes.**
+
+## Findings
+
+### GROCERUN-61-01 — User-level exclusion suppresses reconciliation and other devices
+
+**Severity:** HIGH
+**Files:** `apps/server/src/sync/sync.controller.ts:71-80`, `apps/server/src/sync/sse-broadcast.service.ts:40-48`
+**Tracks:** Logic & Correctness; Data & Persistence
+
+**Problem:** `notifyChanged(..., user.userId)` excludes every SSE connection registered
+under the pushing user ID, not only the connection that originated the push. A push from
+one tab/device therefore suppresses notification to the user's other tabs/devices. More
+importantly, accepted pushes can require a follow-up pull on the originating client:
+`pushListItems` assigns server-authoritative `createdAt`, and soft-deleted restores may use
+a canonical row ID different from the submitted ID. The implementation itself says these
+values converge "on the next pull", but the new exclusion removes that pull trigger. This
+can leave local state permanently divergent until another mutation, visibility change, or
+reconnect happens.
+
+**Fix:** Do not exclude by user ID. The safe minimal fix is to keep notifying all household
+members and rely on collection-scoped routing to reduce the pusher's cost to one targeted
+pull. If avoiding the originating connection remains required, introduce an opaque
+connection/client ID and exclude only that connection after proving every accepted push
+response contains enough canonical state for immediate reconciliation.
+
+### GROCERUN-61-02 — Collection manifests omit rows changed by REST mutations
+
+**Severity:** HIGH
+**Files:** `apps/server/src/stores/stores.service.ts:89-99`, `apps/server/src/sections/sections.service.ts:85-111`, `apps/server/src/lists/lists.service.ts:134-237`, `apps/server/src/lists/lists.service.ts:345-387`
+**Tracks:** Logic & Correctness; Data & Persistence
+
+**Problem:** Before this branch, `SYNC_CHANGED` caused all six collections to pull, so the
+producer-side `collections` arrays were advisory. They are now authoritative, but several
+arrays do not describe all changed tables:
+
+- Deleting a store soft-deletes `listItem`, `list`, `item`, `section`, and `store`, but
+  broadcasts only `['store', 'section']`.
+- Deleting a section sets matching items' `sectionId` to null, but broadcasts only
+  `['section']`.
+- Adding a new catalog item through `addItemToList` can create/restore both an `item` and a
+  `listItem`, but broadcasts only `['list', 'listItem']`.
+- Completing a list increments catalog item statistics, but broadcasts only
+  `['list', 'listItem']`.
+
+Other connected clients now leave the omitted RxDB collections stale. Local mutation hooks
+also omit several of these resyncs, so the REST caller is not consistently protected.
+
+**Fix:** Audit every REST mutation and emit the complete set of changed RxDB collections.
+At minimum: store delete should include all affected collections; section delete should
+include `item`; add-item paths that create/restore catalog items should include `item`; list
+completion should include `item`. Prefer named, typed collection-manifest constants or
+returning mutation effects from domain operations so future cascades cannot silently drift.
+
+### GROCERUN-61-03 — Comment heartbeats never reset the client watchdog
+
+**Severity:** HIGH
+**Files:** `apps/server/src/sync/sync.controller.ts:131-134`, `apps/web/src/core/rxdb/database.ts:625-645`
+**Tracks:** Logic & Correctness; Structure & Quality
+
+**Problem:** The server sends SSE heartbeats as comments (`: heartbeat`), which EventSource
+correctly ignores. The client watchdog resets only for dispatched `open`, `message`, or
+named events. On an otherwise healthy idle stream, no JavaScript event occurs after
+`open`, so the 20-second watchdog fires even though the server wrote a heartbeat at 15
+seconds. The browser then closes and reconnects a healthy stream every 20 seconds, causing
+full initial `RESYNC` pulls, unnecessary auth/database traffic, and connection churn.
+
+**Fix:** Send a named heartbeat event (for example `event: HEARTBEAT\ndata: {}\n\n`) and
+register a matching client listener that only resets the watchdog. Alternatively remove
+the client watchdog and rely on EventSource/network error handling. Add fake-timer coverage
+that advances beyond 20 seconds while heartbeats arrive and asserts no reconnect occurs.
+
+### GROCERUN-61-04 — Shared SyncService cache is not request-scoped
+
+**Severity:** MEDIUM
+**File:** `apps/server/src/sync/sync.service.ts:31-53,64-100`
+**Tracks:** Logic & Correctness; Structure & Quality
+
+**Problem:** Nest services are singleton-scoped, so `accessCache` is shared by concurrent
+requests. Each pull/push clears the same map at method entry. Interleaved requests can evict
+one another's promises, and a future handler that performs two separated accesses can lose
+the promised "within one request" memoization. The cache cannot currently leak one user's
+IDs to another because keys include user IDs, but its lifetime contract is incorrect and
+performance becomes timing-dependent under concurrency.
+
+**Fix:** Create a fresh cache inside each `pull()`/`push()` invocation and pass it into a
+request-local `SyncDeps`, or construct one `deps` object with closure-local memoized
+promises per operation. Avoid request-scoping the entire Nest provider solely for this.
+
+### GROCERUN-61-05 — SSE technical design is materially stale
+
+**Severity:** MEDIUM
+**File:** `wiki/technical-design/sse-resync-broadcast.md`
+**Tracks:** Structure & Quality; Architecture Alignment
+
+**Problem:** The canonical design still describes `NotificationService`, all-stream
+`SYNC_CHANGED` routing, pusher notifications, a 25-second heartbeat, nonexistent
+`unregisterAll`, nonexistent E2E files, and failure handling that is not implemented
+(`res.write` exceptions are described as silently caught). This branch changes the protocol
+semantics, so the stale document will mislead future changes and reviews.
+
+**Fix:** Update the design after the correctness fixes are settled. Document the exact
+collection-manifest contract, actual heartbeat/watchdog behavior, singleton provider
+ownership, and real test inventory. Remove claims about nonexistent APIs and tests.
+
+## Priority Action Items
+
+| Order | Finding | Action |
+|---|---|---|
+| 1 | GROCERUN-61-01 | Restore targeted reconciliation and same-user multi-device delivery. |
+| 2 | GROCERUN-61-02 | Correct every mutation's collection manifest and add cascade/side-effect tests. |
+| 3 | GROCERUN-61-03 | Make heartbeat observable to the watchdog or remove the watchdog. |
+
+## Test Gaps
+
+- No test proves a push-created/restored document converges to server-authoritative fields.
+- No test covers two SSE connections for the same user when one session pushes.
+- No test verifies cascade/side-effect collection manifests for store deletion, section
+  deletion, list item creation, or list completion.
+- No fake-timer test covers an idle healthy SSE connection beyond the watchdog deadline.
+- No concurrency test covers overlapping pull/push calls against `SyncService`.
+- The repository contains no SSE E2E spec despite the technical design claiming two exist.
+
+## Positive Notes
+
+- The duplicate `SseBroadcastService` provider was correctly removed, restoring one
+  application-wide connection registry.
+- Malformed/empty/missing collection payloads retain a safe all-collection fallback.
+- The focused routing helper is small and directly tested.
+- Access cache keys include user IDs, preventing cross-user result reuse.
+- Full uncached tests pass: server 144, web 102, DTO 52.
+
+## Architecture Alignment
+
+- **Relevant ADRs:** ADR 007 (local-first split), ADR 008 (testing strategy).
+- **Relevant designs:** `rxdb-sync-protocol.md`, `sse-resync-broadcast.md`,
+  `data-sync-and-concurrency.md`.
+- **Current constraint:** six independent RxDB collections with targeted SSE-triggered pull.
+- **Potential tension:** optimization must not remove required convergence or same-user
+  multi-device propagation.
+- **Conclusion:** aligned in direction, blocked by correctness details above.

--- a/planning/tickets/notification-data-model-analysis.md
+++ b/planning/tickets/notification-data-model-analysis.md
@@ -1,0 +1,186 @@
+# Ticket Analysis: GROCERUN-32 — Notification data model + server API + sync
+
+## Clarity Assessment
+
+| Dimension | Assessment | Verdict |
+|-----------|-----------|---------|
+| **Goal Clarity** | Persist user-facing household notifications (activity feed data layer). Server creates notification records on mutations, clients sync them via pull-only RxDB collection. | Clear |
+| **Acceptance Criteria** | Implied by title: (1) Prisma Notification model, (2) REST API for notifications, (3) sync integration as pull-only collection. Needs explicit AC — see below. | Clear enough |
+| **Technical Scope** | Server: Prisma schema + migration, NestJS notifications module, sync collection handler, notification creation in existing services. Shared: DTOs. Web: RxDB notification schema + replication wiring. | Clear |
+| **Dependencies** | Child of GROCERUN-11 (Household activity feed epic). No other ticket dependencies — builds on existing sync infrastructure. GROCERUN-33 (#11b) depends on this. | Clear |
+| **Test Strategy** | Unit tests for notification service + sync handler. Server integration tests for REST API + notification creation. Web component tests for RxDB schema. E2E: notification sync journey. | Clear enough |
+
+**Verdict: PROCEED** — All dimensions are sufficiently clear to produce a concrete implementation plan.
+
+---
+
+## Affected Code
+
+### Server (`apps/server/`)
+
+| File | Current behavior | Change |
+|------|-----------------|--------|
+| `prisma/schema.prisma` | 11 models, no Notification | Add `Notification` model |
+| `prisma/migrations/` | Existing migrations | New migration for Notification table |
+| `src/sync/sync.service.ts` | `SyncCollection` = 6 collections, `SUPPORTED_COLLECTIONS` array, switch dispatch | Add `'notification'` to type, array, switch, and `getHouseholdMemberIds` |
+| `src/sync/sync.types.ts` | `SyncDocument`, `PullResponse`, `SyncCheckpoint` | No change (generic types work) |
+| `src/sync/sync-helpers.ts` | `pullByAccess()` generic pull handler | No change (reuse as-is) |
+| `src/sync/collections/` | 6 collection sync handlers (store-sync.ts, item-sync.ts, etc.) | Add `notification-sync.ts` |
+| `src/sync/sync-deps.ts` | Access helpers for stores/households | Add `getAccessibleNotificationHouseholdIds` or reuse `getAccessibleHouseholdIdsForSync` |
+| `src/shared/notification.service.ts` | Fire-and-forget SSE broadcast (byStore, byHousehold) | No change — stays as SSE sync helper |
+| `src/shared/shared.module.ts` | Exports NotificationService, PrismaService, etc. | Export new UserNotificationService |
+| `src/items/items.service.ts` | Calls `notify.byStore()` after mutations | Add `userNotify.createForHousehold()` calls |
+| `src/lists/lists.service.ts` | Calls `notify.byStore()` after mutations | Add `userNotify.createForHousehold()` calls |
+| `src/stores/stores.service.ts` | Calls `notify.byHousehold()` after mutations | Add `userNotify.createForHousehold()` calls |
+| `src/sections/sections.service.ts` | Calls `notify.byStore()` after mutations | Add `userNotify.createForHousehold()` calls |
+| `src/households/households.service.ts` | Calls `notify.byHousehold()` after mutations | Add `userNotify.createForHousehold()` calls |
+| `src/invitations/invitations.service.ts` | Calls `notify.byHousehold()` on invitation complete | Add `userNotify.createForHousehold()` calls |
+
+### New server files
+
+| File | Purpose |
+|------|---------|
+| `src/notifications/notifications.module.ts` | NestJS module |
+| `src/notifications/notifications.controller.ts` | REST API: list, mark read, mark all read |
+| `src/notifications/notifications.service.ts` | Query + mark-read logic |
+| `src/notifications/user-notification.service.ts` | Notification creation + SSE dispatch (dual-dispatch) |
+| `src/notifications/notification-sync.ts` | Sync document converter |
+| `src/notifications/dto/` | NestJS DTOs (if needed beyond shared) |
+
+### Shared (`apps/_shared/dtos/`)
+
+| File | Change |
+|------|--------|
+| `src/index.ts` | Add `NotificationSchema`, `NotificationDto`, `NotificationType` enum |
+
+### Web (`apps/web/`)
+
+| File | Current behavior | Change |
+|------|-----------------|--------|
+| `src/core/rxdb/schema.ts` | 6 RxDB schemas | Add `NotificationSchema` + `NotificationDocType` |
+| `src/core/rxdb/database.ts` | 6 collections, `RXDB_NAME = 'grocerun-v9'` | Add notification collection, bump `RXDB_NAME` to `'grocerun-v10'`, add `startNotificationReplication()` + `resyncNotification()` |
+| `src/core/rxdb/collections.ts` | (if exists) Collection name exports | Add `'notification'` |
+
+---
+
+## Solution Designs
+
+### Option A: Infrastructure Only (Minimal — S)
+
+**Scope:** Prisma model + migration + shared DTOs + NestJS notifications module (REST read API only) + sync pull collection + RxDB schema. No notification creation in existing services.
+
+**Files:**
+- `prisma/schema.prisma` — Add Notification model
+- `prisma/migrations/xxx_notification/` — Migration
+- `apps/_shared/dtos/src/index.ts` — NotificationSchema, NotificationDto
+- `apps/server/src/notifications/` — Module, controller (GET list, PATCH read), service
+- `apps/server/src/sync/sync.service.ts` — Add 'notification' to SyncCollection
+- `apps/server/src/sync/collections/notification-sync.ts` — Pull handler
+- `apps/web/src/core/rxdb/schema.ts` — NotificationRxSchema
+- `apps/web/src/core/rxdb/database.ts` — Collection + replication wiring
+
+**Pros:** Smallest change, zero risk to existing mutation paths, clean data layer.
+**Cons:** No notifications are ever created — #11b can't function without a creation path. The sync pulls an empty collection.
+**Risk:** Low
+
+### Option B: Full Data Pipeline (Balanced — M) — RECOMMENDED
+
+**Scope:** Everything in Option A PLUS a `UserNotificationService` that creates notification records and dispatches SSE, wired into existing mutation services.
+
+**Files (additional vs Option A):**
+- `apps/server/src/notifications/user-notification.service.ts` — `createForHousehold(householdId, type, actorId, entityType, entityId, message)` → creates N notification records (one per household member except actor) + calls `sseBroadcast.notifyChanged(memberIds, {collections: ['notification'], reason: 'notification_created'})`
+- `apps/server/src/items/items.service.ts` — Call `userNotify.createForHousehold()` on add/update/delete
+- `apps/server/src/lists/lists.service.ts` — Call on create/complete/delete
+- `apps/server/src/stores/stores.service.ts` — Call on add
+- `apps/server/src/sections/sections.service.ts` — Call on add
+- `apps/server/src/households/households.service.ts` — Call on member join/leave
+- `apps/server/src/invitations/invitations.service.ts` — Call on invitation accepted
+
+**Notification creation pattern:**
+```typescript
+// In items.service.ts after creating an item:
+await this.userNotify.createForHousehold({
+  householdId,
+  type: 'item_added',
+  actorId: userId,
+  actorName: userName,
+  entityType: 'item',
+  entityId: item.id,
+  message: `${userName} added ${item.name} to ${storeName}`,
+});
+// Existing SSE sync call stays:
+this.notify.byStore(storeId, ['item'], 'item_added');
+```
+
+**Pros:** Complete data pipeline — notifications are created, synced, and ready for #11b UI. #11b only needs React hooks + bell component.
+**Cons:** Touches 6 existing services. Each needs constructor injection of `UserNotificationService`.
+**Risk:** Medium — existing service tests need updating, but changes are additive (new call after existing mutations, no change to existing logic).
+
+### Option C: Preferences + Enum Table (Strategic — L)
+
+**Scope:** Everything in Option B PLUS a `NotificationPreference` model (per-user per-type opt-in/opt-out), notification types as a Prisma enum table, and batch creation optimization.
+
+**Pros:** Future-proof, supports notification preferences from day one.
+**Cons:** Over-engineering for MVP. Preferences can be added later without schema migration pain (additive). Enum table adds complexity for no current value.
+**Risk:** Medium-High — scope creep, more surface area to test.
+
+---
+
+## Recommendation
+
+**Option B: Full Data Pipeline.**
+
+Rationale:
+1. #11a is the data foundation — without notification creation, the entire pipeline is hollow.
+2. The `UserNotificationService` cleanly separates user-facing notifications from the existing SSE sync `NotificationService`.
+3. Changes to existing services are purely additive (new call after existing mutations).
+4. #11b can then focus purely on UI (bell, toast, hooks) without touching server code.
+5. Aligns with ADR-007: notifications are server-authoritative (transactional side effects, server confirmation required).
+
+---
+
+## Architecture Alignment
+
+- **Relevant ADRs:** ADR-007 (Phase 4 Local-First Strategy) — notifications are server-authoritative per criteria (2) transactional side effects and (3) requires server confirmation. Pull-only sync, no push.
+- **Relevant rules:** `wiki/rules/rxdb.md` — explicit `startXReplication` + `resyncX` pattern, no factory abstraction. `wiki/rules/coding-standards.md` — Zod at API boundaries, constructor injection, no `any`.
+- **Relevant technical designs:** `wiki/technical-design/rxdb-sync-protocol.md` — new collection follows existing pull-only pattern (like store, section, list, household).
+- **Current project-status constraints:** Phase 4 active (RxDB local-first shopping). Notification sync extends the existing protocol, doesn't change it.
+- **Potential tension:** None. The notification collection is a natural addition to the existing sync protocol. The `UserNotificationService` is a new concern, not a modification of existing `NotificationService`.
+- **User decision needed:** No.
+- **Conclusion:** Aligned.
+
+---
+
+## Test Strategy
+
+### Unit tests
+- **`UserNotificationService`** — Test `createForHousehold()`: creates N records for N members, excludes actor, dispatches SSE with correct member IDs. Mock PrismaService + SseBroadcastService.
+- **`NotificationsService`** — Test `list()`, `markRead()`, `markAllRead()`: correct Prisma queries, filtering by userId + household access.
+- **`notification-sync.ts`** — Test `notificationToSyncDoc()`: correct field mapping, ISO-8601 date conversion.
+
+### Server integration tests
+- **REST API:** `GET /notifications` returns only current user's notifications, filtered by household access. `PATCH /notifications/:id/read` marks as read. `PATCH /notifications/read-all` marks all as read.
+- **Notification creation:** After item creation via API, a notification record exists in DB for all household members except the actor.
+- **Sync pull:** `GET /sync/notification/pull` returns notifications filtered by user, respects checkpoint pagination.
+- **SSE dispatch:** After mutation, SSE event includes `['notification']` in collections.
+
+### Web component tests
+- **RxDB schema:** Notification collection creates, documents validate against schema, `updatedAt` index works.
+- **Replication:** Pull-only replication fetches from `/sync/notification/pull`, no push endpoint called.
+
+### E2E journey semantics
+- **Affected:** New journey — "User sees notification after household member adds item." This is a new journey, not a modification of existing ones.
+- **Existing journeys:** Unaffected — notification creation is additive, doesn't change existing mutation behavior.
+
+### Manual/UAT
+- User A adds an item → User B sees a notification in the bell (once #11b is done).
+- For #11a: verify via API that notification records exist after mutations.
+- Verify sync: two browser sessions, one creates an item, the other pulls notifications via sync.
+
+---
+
+## Dependencies & Blockers
+
+- **No blockers.** All infrastructure exists (sync protocol, SSE, RxDB, Prisma).
+- **Blocks:** GROCERUN-33 (#11b — Notification bell UI + dual-dispatch hooks) depends on this ticket.
+- **Parent:** GROCERUN-11 (Household activity feed epic).

--- a/planning/tickets/notification-data-model-analysis.md
+++ b/planning/tickets/notification-data-model-analysis.md
@@ -22,13 +22,13 @@
 |------|-----------------|--------|
 | `prisma/schema.prisma` | 11 models, no Notification | Add `Notification` model |
 | `prisma/migrations/` | Existing migrations | New migration for Notification table |
-| `src/sync/sync.service.ts` | `SyncCollection` = 6 collections, `SUPPORTED_COLLECTIONS` array, switch dispatch | Add `'notification'` to type, array, switch, and `getHouseholdMemberIds` |
+| `src/sync/sync.service.ts` | `SyncCollection` is derived from the canonical collection list, pull/push switches dispatch existing collections | Add `'notification'` to the canonical list and pull/push switches; do not add unreachable notification handling to `getHouseholdMemberIds` |
 | `src/sync/sync.types.ts` | `SyncDocument`, `PullResponse`, `SyncCheckpoint` | No change (generic types work) |
 | `src/sync/sync-helpers.ts` | `pullByAccess()` generic pull handler | No change (reuse as-is) |
 | `src/sync/collections/` | 6 collection sync handlers (store-sync.ts, item-sync.ts, etc.) | Add `notification-sync.ts` |
 | `src/sync/sync-deps.ts` | Access helpers for stores/households | Add `getAccessibleNotificationHouseholdIds` or reuse `getAccessibleHouseholdIdsForSync` |
-| `src/shared/notification.service.ts` | Fire-and-forget SSE broadcast (byStore, byHousehold) | No change — stays as SSE sync helper |
-| `src/shared/shared.module.ts` | Exports NotificationService, PrismaService, etc. | Export new UserNotificationService |
+| `src/shared/sse-sync-broadcast.service.ts` | Fire-and-forget SSE broadcast helper (`SseSyncBroadcastService`) | No change — stays as the SSE sync helper |
+| `src/shared/shared.module.ts` | Exports `SseSyncBroadcastService`, PrismaService, etc. | Export new `UserNotificationService` |
 | `src/items/items.service.ts` | Calls `notify.byStore()` after mutations | Add `userNotify.createForHousehold()` calls |
 | `src/lists/lists.service.ts` | Calls `notify.byStore()` after mutations | Add `userNotify.createForHousehold()` calls |
 | `src/stores/stores.service.ts` | Calls `notify.byHousehold()` after mutations | Add `userNotify.createForHousehold()` calls |
@@ -43,7 +43,7 @@
 | `src/notifications/notifications.module.ts` | NestJS module |
 | `src/notifications/notifications.controller.ts` | REST API: list, mark read, mark all read |
 | `src/notifications/notifications.service.ts` | Query + mark-read logic |
-| `src/notifications/user-notification.service.ts` | Notification creation + SSE dispatch (dual-dispatch) |
+| `src/shared/user-notification.service.ts` | Notification creation + SSE dispatch (dual-dispatch) |
 | `src/notifications/notification-sync.ts` | Sync document converter |
 | `src/notifications/dto/` | NestJS DTOs (if needed beyond shared) |
 
@@ -88,7 +88,7 @@
 **Scope:** Everything in Option A PLUS a `UserNotificationService` that creates notification records and dispatches SSE, wired into existing mutation services.
 
 **Files (additional vs Option A):**
-- `apps/server/src/notifications/user-notification.service.ts` — `createForHousehold(householdId, type, actorId, entityType, entityId, message)` → creates N notification records (one per household member except actor) + calls `sseBroadcast.notifyChanged(memberIds, {collections: ['notification'], reason: 'notification_created'})`
+- `apps/server/src/shared/user-notification.service.ts` — `createForHousehold(householdId, type, actorId, entityType, entityId, message)` → creates N notification records (one per household member except actor) + calls `sseBroadcast.notifyChanged(memberIds, {collections: ['notification'], reason: 'notification_created'})`
 - `apps/server/src/items/items.service.ts` — Call `userNotify.createForHousehold()` on add/update/delete
 - `apps/server/src/lists/lists.service.ts` — Call on create/complete/delete
 - `apps/server/src/stores/stores.service.ts` — Call on add
@@ -132,7 +132,7 @@ this.notify.byStore(storeId, ['item'], 'item_added');
 
 Rationale:
 1. #11a is the data foundation — without notification creation, the entire pipeline is hollow.
-2. The `UserNotificationService` cleanly separates user-facing notifications from the existing SSE sync `NotificationService`.
+2. The `UserNotificationService` cleanly separates user-facing notifications from the existing SSE sync `SseSyncBroadcastService`.
 3. Changes to existing services are purely additive (new call after existing mutations).
 4. #11b can then focus purely on UI (bell, toast, hooks) without touching server code.
 5. Aligns with ADR-007: notifications are server-authoritative (transactional side effects, server confirmation required).
@@ -145,7 +145,7 @@ Rationale:
 - **Relevant rules:** `wiki/rules/rxdb.md` — explicit `startXReplication` + `resyncX` pattern, no factory abstraction. `wiki/rules/coding-standards.md` — Zod at API boundaries, constructor injection, no `any`.
 - **Relevant technical designs:** `wiki/technical-design/rxdb-sync-protocol.md` — new collection follows existing pull-only pattern (like store, section, list, household).
 - **Current project-status constraints:** Phase 4 active (RxDB local-first shopping). Notification sync extends the existing protocol, doesn't change it.
-- **Potential tension:** None. The notification collection is a natural addition to the existing sync protocol. The `UserNotificationService` is a new concern, not a modification of existing `NotificationService`.
+- **Potential tension:** None. The notification collection is a natural addition to the existing sync protocol. The `UserNotificationService` is a new concern, not a modification of existing `SseSyncBroadcastService`.
 - **User decision needed:** No.
 - **Conclusion:** Aligned.
 
@@ -160,9 +160,10 @@ Rationale:
 
 ### Server integration tests
 - **REST API:** `GET /notifications` returns only current user's notifications, filtered by household access. `PATCH /notifications/:id/read` marks as read. `PATCH /notifications/read-all` marks all as read.
+- **Boundary validation:** Define shared Zod schemas for pagination query parameters and notification route IDs; controllers use the project Zod validation pipe rather than manually parsing input.
 - **Notification creation:** After item creation via API, a notification record exists in DB for all household members except the actor.
 - **Sync pull:** `GET /sync/notification/pull` returns notifications filtered by user, respects checkpoint pagination.
-- **SSE dispatch:** After mutation, SSE event includes `['notification']` in collections.
+- **SSE dispatch:** After notification creation or a read-state mutation, SSE event includes `['notification']` in collections so all of the recipient's connected devices converge.
 
 ### Web component tests
 - **RxDB schema:** Notification collection creates, documents validate against schema, `updatedAt` index works.

--- a/planning/tickets/notification-data-model.md
+++ b/planning/tickets/notification-data-model.md
@@ -1,0 +1,436 @@
+# Ticket: GROCERUN-32 — Notification data model + server API + sync
+
+**Status:** planned
+**Source:** GROCERUN-11 (Household activity feed epic), FEATURE-INTAKE.md "Household activity feed" + "Push notifications for household events"
+**Branch:** (not yet started)
+**Plane:** GROCERUN-32, child of GROCERUN-11, estimate: M
+**Blocks:** GROCERUN-33 (#11b — Notification bell UI + dual-dispatch hooks)
+
+## Background
+
+The household activity feed epic (#11) needs a data foundation: persisted user-facing notifications that sync to client devices. Currently, the only notification mechanism is a fire-and-forget SSE broadcast (`NotificationService`) that tells clients to re-pull sync collections — there are no persisted notification records, no notification API, and no notification sync collection.
+
+This ticket creates the full server-side data pipeline: Prisma model, REST API, sync integration, and notification creation in existing mutation services. #11b will build the client-side bell UI and React hooks on top of this.
+
+## User-Facing Goal
+
+A household member performs an action (adds an item, completes a list, joins the household). Other household members see a notification about it. This ticket delivers the data layer — actual UI comes in #11b.
+
+## Acceptance Criteria
+
+1. **Prisma Notification model exists** with fields: id, createdAt, updatedAt, deleted, deletedAt, householdId, userId, type, actorId, actorName, entityType, entityId, message, readAt, category, dismissedAt. Migration applied.
+2. **Shared DTOs exist** — `NotificationSchema` (Zod) + `NotificationDto` type in `apps/_shared/dtos/`.
+3. **REST API works:**
+   - `GET /notifications` — returns current user's notifications (filtered by household access), sorted newest-first, paginated.
+   - `PATCH /notifications/:id/read` — marks a single notification as read.
+   - `PATCH /notifications/read-all` — marks all unread notifications as read.
+4. **Sync pull collection works** — `GET /sync/notification/pull` returns notifications for the current user, checkpoint-paginated, respecting the tombstone window.
+5. **RxDB notification collection exists** — schema, doc type, pull-only replication wired in `database.ts`, `RXDB_NAME` bumped.
+6. **SSE routing is collection-scoped** — `sharedPullStreams` changed from `Set<Subject>` to `Map<string, Subject>`, `SYNC_CHANGED` events parsed for `collections` array, RESYNC only emitted to matching streams. (Prerequisite for efficient notification dispatch.)
+7. **Self-notify skipped on push** — pusher's userId excluded from `SseBroadcastService.notifyChanged` so optimistic local writes don't trigger redundant re-pulls.
+8. **Access queries memoized** — `getAccessibleStoreIdsForSync`/`getAccessibleHouseholdIdsForSync` cached per-request so 5 collections don't each make the same Prisma query.
+9. **Notifications are created on key mutations** (staged — prove pattern first, then expand):
+   - Stage 1 (prove pattern): Store added
+   - Stage 2 (expand): Section added, List created, List completed, Invitation accepted (member joined)
+10. **SSE dispatch** — notification creation triggers `SYNC_CHANGED` with `['notification']` collection so connected clients re-pull.
+11. **Existing `NotificationService` renamed** — SSE sync broadcast helper renamed to `SseSyncBroadcastService` to disambiguate from `UserNotificationService`. New `UserNotificationService` handles user-facing notifications.
+12. **All tests pass** — unit, server integration, web component. No regressions in existing tests.
+
+## Scope
+
+### In scope
+- **SSE transport fixes** (prerequisite): collection-scoped SSE routing, skip self-notify on push, memoize access queries
+- Prisma `Notification` model + migration (touches 3 models: Notification, User, Household)
+- Shared Zod DTOs for notifications
+- NestJS `NotificationsModule`: controller (REST read/mark-read) + `NotificationsService`
+- `UserNotificationService` in `SharedModule` (global): creates notification records + dispatches SSE
+- Rename existing `NotificationService` → `SseSyncBroadcastService`
+- Sync integration: `'notification'` pull-only collection
+- RxDB notification schema + pull replication wiring
+- Notification creation calls (staged): prove with 1 service, expand to 4 total
+
+### Non-scope
+- Notification bell UI, toast component, React hooks (#11b)
+- Push notifications / service worker (future, significant scope per FEATURE-INTAKE.md)
+- Notification preferences / opt-out per type
+- Notification types as enum table (string type field is sufficient for MVP)
+- Notification deletion by user (soft-delete via sync tombstone is enough)
+- Real-time collaboration features (chat, presence)
+
+## Relevant Context
+
+### ADRs
+- **ADR-007** (Phase 4 Local-First Strategy): Notifications are server-authoritative per criteria (2) transactional side effects, (3) requires server confirmation. Pull-only sync, no push. Aligns with existing server-authoritative collections (store, section, list, household).
+
+### Coding rules
+- `wiki/rules/rxdb.md`: Explicit `startNotificationReplication()` + `resyncNotification()` pattern — no factory abstraction. All schemas version 0, primary key `id` (cuid2).
+- `wiki/rules/coding-standards.md`: `strict: true`, Zod at API boundaries, constructor injection, no `any`, conventional commits.
+- `wiki/rules/prisma.md`: Soft-delete pattern (`deleted`, `deletedAt`), `@@index([updatedAt, id])` for sync checkpoint.
+- `wiki/rules/nestjs.md`: Module structure, validation.
+
+### Technical designs
+- `wiki/technical-design/rxdb-sync-protocol.md`: New pull-only collection follows existing pattern. `pullByAccess()` helper reused. SSE `SYNC_CHANGED` event with `{collections, reason}` payload.
+
+### Project status constraints
+- Phase 4 active (RxDB local-first shopping). This extends the sync protocol, doesn't change it.
+- `RXDB_NAME` bump required — existing clients will re-sync all collections on first load after upgrade (acceptable, same as previous bumps).
+
+## Affected Areas
+
+| Area | Files | Change type |
+|------|-------|-------------|
+| Server schema | `apps/server/prisma/schema.prisma` | New model + relations on User, Household |
+| Server migration | `apps/server/prisma/migrations/` | New migration |
+| Server notifications | `apps/server/src/notifications/` (new) | New module (REST API only) |
+| Server sync | `apps/server/src/sync/sync.service.ts`, `apps/server/src/sync/collections/notification-sync.ts` (new) | Additive + push() exhaustiveness |
+| Server shared | `apps/server/src/shared/shared.module.ts`, `apps/server/src/shared/notification.service.ts` | Rename + export new service |
+| Server SSE | `apps/server/src/sync/sse-broadcast.service.ts` | Skip self-notify on push |
+| Server services | `stores.service.ts`, `sections.service.ts`, `lists.service.ts`, `invitations.service.ts` | Additive (new call after mutations) |
+| Shared DTOs | `apps/_shared/dtos/src/index.ts` | Additive |
+| Web RxDB | `apps/web/src/core/rxdb/schema.ts`, `apps/web/src/core/rxdb/database.ts` | Additive + RXDB_NAME bump + SSE routing fix |
+
+## Implementation Outline
+
+### Phase 0: SSE Transport Fixes (Prerequisite)
+
+0a. **Fix SSE routing** (`apps/web/src/core/rxdb/database.ts`):
+    - Change `sharedPullStreams` from `Set<Subject>` to `Map<string, Subject>` (keyed by collection name)
+    - Parse `event.data` in `SYNC_CHANGED` handler to extract `collections` array
+    - Only emit `RESYNC` to matching streams, not all streams
+    - Update `registerPullStream` to accept collection name + subject
+    - ~50 lines
+
+0b. **Skip self-notify on push** (`apps/server/src/sync/sse-broadcast.service.ts`, `apps/server/src/sync/sync.service.ts`):
+    - Thread pusher's `userId` to `SseBroadcastService.notifyChanged`
+    - Exclude pusher from the SSE recipient list (their local state is already correct from optimistic write)
+    - ~10 lines
+
+0c. **Memoize access queries** (`apps/server/src/sync/sync.service.ts`):
+    - Cache `getAccessibleStoreIdsForSync` / `getAccessibleHouseholdIdsForSync` per-request (or 5-second TTL)
+    - Eliminates 5 redundant Prisma queries during `resyncAll()`
+    - ~15 lines
+
+0d. **Rename `NotificationService` → `SseSyncBroadcastService`** (`apps/server/src/shared/`):
+    - Rename file, class, and all 6 import sites (items, lists, stores, sections, households, invitations services)
+    - Prevents permanent confusion with `UserNotificationService`
+    - ~9 files touched, mechanical rename
+
+### Phase 1: Data Model + DTOs
+
+1. **Prisma Notification model** (`apps/server/prisma/schema.prisma`):
+   ```prisma
+   model Notification {
+     id          String    @id @default(cuid())
+     createdAt   DateTime  @default(now())
+     updatedAt   DateTime  @updatedAt
+     deleted     Boolean   @default(false)
+     deletedAt   DateTime?
+
+     householdId String
+     household   Household @relation(fields: [householdId], references: [id])
+     userId      String
+     user        User      @relation(fields: [userId], references: [id])
+
+type        String
+      actorId     String
+      actorName   String
+      entityType  String
+      entityId    String?
+      message     String
+      readAt      DateTime?
+      category    String?
+      dismissedAt DateTime?
+
+      @@index([updatedAt, id])
+      @@index([userId, readAt])
+    }
+    ```
+    Add `notifications Notification[]` relation to `User` and `Household` models.
+    Note: `category` and `dismissedAt` are nullable columns added now to avoid migration churn in #11b. `category` for bell grouping (items/lists/members), `dismissedAt` distinct from `readAt` (read = seen in feed, dismissed = cleared from bell).
+
+2. **Migration**: `npx prisma migrate dev --name add_notification_model`
+
+3. **Shared DTOs** (`apps/_shared/dtos/src/index.ts`):
+   ```typescript
+   export const NotificationTypeSchema = z.enum([
+     'store_added', 'section_added',
+     'list_created', 'list_completed',
+     'member_joined',
+   ]);
+
+   export const NotificationSchema = z.object({
+     id: z.string(),
+     updatedAt: z.string(),
+     _deleted: z.boolean(),
+     householdId: z.string(),
+     userId: z.string(),
+     type: NotificationTypeSchema,
+     actorId: z.string(),
+     actorName: z.string(),
+     entityType: z.string(),
+     entityId: z.string().nullable(),
+     message: z.string(),
+     readAt: z.string().nullable(),
+     category: z.string().nullable(),
+     dismissedAt: z.string().nullable(),
+   });
+   export type NotificationDto = z.infer<typeof NotificationSchema>;
+   ```
+
+### Phase 2: NestJS Notifications Module
+
+4. **`UserNotificationService`** (`apps/server/src/shared/user-notification.service.ts`):
+   - Lives in `SharedModule` (global), not `NotificationsModule` — same pattern as `SseSyncBroadcastService`
+   - Constructor: `PrismaService`, `SseBroadcastService`
+   - `createForHousehold({ householdId, type, actorId, entityType, entityId, message, category? })`:
+     - Fetch household members + actor name in one query: `prisma.household.findUnique({ include: { users: { select: { id: true, name: true } } } })`
+     - Exclude actor from recipient list
+     - Create one `Notification` record per member via `prisma.notification.createMany()`
+     - Call `sseBroadcast.notifyChanged(recipientIds, { collections: ['notification'], reason: 'notification_created' })`
+     - Fire-and-forget pattern (log errors, don't block mutation)
+
+5. **`NotificationsService`** (`apps/server/src/notifications/notifications.service.ts`):
+   - Constructor: `PrismaService`
+   - `list(userId, { limit, offset })` — query `prisma.notification.findMany({ where: { userId, deleted: false }, orderBy: { createdAt: 'desc' }, take, skip })`
+   - `markRead(userId, notificationId)` — verify ownership, set `readAt = now()`
+   - `markAllRead(userId)` — `prisma.notification.updateMany({ where: { userId, readAt: null, deleted: false }, data: { readAt: now() } })`
+
+6. **`NotificationsController`** (`apps/server/src/notifications/notifications.controller.ts`):
+   - `@Controller('notifications')` with `@UseGuards(AuthGuard)`
+   - `@Get()` — list, query params for pagination
+   - `@Patch(':id/read')` — mark single read
+   - `@Patch('read-all')` — mark all read
+
+7. **`NotificationsModule`** (`apps/server/src/notifications/notifications.module.ts`):
+   - Providers: `NotificationsService` (REST read/mark-read queries only)
+   - Exports: none (REST API module, not consumed by other modules)
+   - Imports: `PrismaModule` (or rely on global `PrismaService`)
+
+8. **Register in `AppModule`** — add `NotificationsModule` to imports.
+
+9. **Export `UserNotificationService` from `SharedModule`** — it lives in `SharedModule` (global), not `NotificationsModule`. Same pattern as `SseSyncBroadcastService`. `NotificationsModule` only contains the REST API (controller + `NotificationsService`).
+
+### Phase 3: Sync Integration
+
+10. **`notification-sync.ts`** (`apps/server/src/sync/collections/notification-sync.ts`):
+    ```typescript
+    export function notificationToSyncDoc(n: Notification): SyncDocument {
+      return {
+        id: n.id,
+        updatedAt: n.updatedAt.toISOString(),
+        _deleted: n.deleted,
+        householdId: n.householdId,
+        userId: n.userId,
+        type: n.type,
+        actorId: n.actorId,
+        actorName: n.actorName,
+        entityType: n.entityType,
+        entityId: n.entityId,
+        message: n.message,
+        readAt: n.readAt?.toISOString() ?? null,
+      };
+    }
+
+    export async function pullNotifications(deps, checkpoint, limit, userId): Promise<PullResponse> {
+      return pullByAccess({
+        deps, checkpoint, limit, userId,
+        model: deps.prisma.notification,
+        toDoc: notificationToSyncDoc,
+buildBaseFilter: async (d, u) => {
+           // Notifications are filtered by userId, not household access.
+           // Do NOT add `deleted: false` here — buildPullWhere handles tombstones.
+           return { userId: u };
+         },
+      });
+    }
+    ```
+    Note: `buildBaseFilter` uses `userId` directly — notifications are personal, not household-scoped for sync purposes. The `householdId` field is for reference/display only.
+
+11. **Update `SyncService`** (`apps/server/src/sync/sync.service.ts`):
+    - Add `'notification'` to `SyncCollection` type
+    - Add `'notification'` to `SUPPORTED_COLLECTIONS` array
+    - Add case in `pull()` switch → `pullNotifications(deps, checkpoint, limit, userId)`
+    - Add `case 'notification': return [];` to `push()` switch (notifications are pull-only, no push handler — matches section/list/store/household pattern)
+    - Do NOT add a case to `getHouseholdMemberIds()` — that function is only called from the push() handler, and notifications have no push path. Adding it would be unreachable dead code.
+
+### Phase 4: RxDB Client Schema
+
+12. **Notification RxDB schema** (`apps/web/src/core/rxdb/schema.ts`):
+    ```typescript
+    export interface NotificationDocType {
+      id: string;
+      updatedAt: string;
+      householdId: string;
+      userId: string;
+      type: string;
+      actorId: string;
+      actorName: string;
+      entityType: string;
+      entityId: string | null;
+      message: string;
+      readAt: string | null;
+    }
+
+    export const notificationSchema: RxJsonSchema<NotificationDocType> = {
+      version: 0,
+      primaryKey: 'id',
+      type: 'object',
+      properties: {
+        id: { type: 'string', maxLength: 30 },
+        updatedAt: { type: 'string', format: 'date-time', maxLength: 30 },
+        householdId: { type: 'string', maxLength: 30 },
+        userId: { type: 'string', maxLength: 30 },
+        type: { type: 'string' },
+        actorId: { type: 'string', maxLength: 30 },
+        actorName: { type: 'string' },
+        entityType: { type: 'string' },
+        entityId: { type: ['string', 'null'], maxLength: 30 },
+        message: { type: 'string' },
+        readAt: { type: ['string', 'null'], format: 'date-time' },
+      },
+      required: ['id', 'updatedAt', 'householdId', 'userId', 'type', 'actorId', 'actorName', 'entityType', 'message'],
+      indexes: ['updatedAt'],
+    };
+    ```
+
+13. **Database wiring** (`apps/web/src/core/rxdb/database.ts`):
+    - Add `notification` to `GrocerunCollections` type
+    - Add `notificationSchema` to `addCollections()` call
+    - Bump `RXDB_NAME` from `'grocerun-v9'` to `'grocerun-v10'`
+    - Add `let notificationPullStream$: Subject<void> | null = null`
+    - Add `export function resyncNotification()` — emits into pull stream
+    - Add `function startNotificationReplication(collection)` — calls `startPullReplication({ collection, basePath: '/api/v1/sync/notification', replicationIdentifier: 'grocerun-notification-sync-v1', pullStream$: notificationPullStream$, enablePush: false })`
+    - Call `startNotificationReplication(notificationCollection)` in `initDb()`
+    - Register pull stream via `registerPullStream(notificationPullStream$)`
+
+### Phase 5: Notification Creation in Existing Services (Staged)
+
+14. **Stage 1 — Prove the pattern with one creation point:**
+
+    Wire `UserNotificationService` into `stores.service.ts`. After `createStore()` + existing `notify.byHousehold()` call, add:
+    ```typescript
+    this.userNotify.createForHousehold({
+      householdId, type: 'store_added', actorId: userId,
+      entityType: 'store', entityId: store.id,
+      message: `added store "${store.name}"`,
+      category: 'stores',
+    }).catch(err => this.logger.error('Notification creation failed', err));
+    ```
+
+    Verify end-to-end: Prisma record created → SSE dispatched → client re-pulls notification collection → RxDB document appears. Unit + integration tests confirm the pattern works.
+
+15. **Stage 2 — Expand to remaining creation points:**
+
+    Once Stage 1 is verified, add notification creation to:
+    - **`sections.service.ts`** (after `createSection`): `type: 'section_added'`, `category: 'stores'`
+    - **`lists.service.ts`** (after `createList`): `type: 'list_created'`, `category: 'lists'`
+    - **`lists.service.ts`** (after `completeList`): `type: 'list_completed'`, `category: 'lists'`
+    - **`invitations.service.ts`** (after `joinHousehold`): `type: 'member_joined'`, `category: 'members'`
+
+    Note: `items.service.ts` has no REST create/delete — items are created via sync push or `lists.service.ts:addItemToList`. `households.service.ts` has no member-join method — joining happens in `invitations.service.ts:joinHousehold`. `lists.service.ts` has no `deleteList` method.
+
+    **Important:** Notification creation is fire-and-forget (same pattern as existing `notify` calls). Errors are logged but don't block the mutation. The mutation has already succeeded by the time notification creation runs.
+
+16. **Actor name resolution in `UserNotificationService.createForHousehold`** — single query, fold actor name into household member fetch:
+    ```typescript
+    async createForHousehold({ householdId, type, actorId, entityType, entityId, message, category }) {
+      const household = await this.prisma.household.findUnique({
+        where: { id: householdId },
+        include: { users: { select: { id: true, name: true } } },
+      });
+      if (!household) return;
+      const actor = household.users.find(u => u.id === actorId);
+      const actorName = actor?.name ?? 'Unknown';
+      const recipientIds = household.users.filter(u => u.id !== actorId).map(u => u.id);
+      if (recipientIds.length === 0) return;
+      await this.prisma.notification.createMany({
+        data: recipientIds.map(userId => ({
+          householdId, userId, type, actorId, actorName,
+          entityType, entityId, message, category,
+        })),
+      });
+      this.sse.notifyChanged(recipientIds, { collections: ['notification'], reason: 'notification_created' });
+    }
+    ```
+    One query instead of two — the household member fetch already includes `name`, so the actor is found in the result array.
+
+## Test Strategy
+
+### Unit tests
+- **`UserNotificationService`** — `createForHousehold()`: creates N records for N-1 members (excludes actor), dispatches SSE with correct recipient IDs, handles missing household/user gracefully, fire-and-forget error handling.
+- **`NotificationsService`** — `list()`: correct Prisma query, pagination. `markRead()`: ownership check, sets `readAt`. `markAllRead()`: updates only current user's unread.
+- **`notificationToSyncDoc()`** — Correct field mapping, ISO-8601 conversion, null handling for `entityId` and `readAt`.
+
+### Server integration tests
+- `GET /notifications` — returns only current user's notifications, sorted newest-first, respects pagination.
+- `PATCH /notifications/:id/read` — marks as read, 403 if not owner.
+- `PATCH /notifications/read-all` — marks all unread as read.
+- `GET /sync/notification/pull` — returns notifications for current user, checkpoint pagination works, tombstone window respected.
+- **Tombstone delivery test** — create notification, soft-delete it, pull, verify `_deleted: true` in result. (Would catch the `deleted: false` in buildBaseFilter bug.)
+- After `POST /stores` (create store), a notification record exists in DB for all household members except the actor.
+- After mutation, SSE event includes `['notification']` in collections array.
+- **SSE routing test** — `SYNC_CHANGED` with `['notification']` only triggers notification pull, not other collections.
+- **Self-notify skip test** — push mutation does not send SSE to the pusher.
+
+### Web component tests
+- Notification RxDB collection creates and validates documents against schema.
+- Pull-only replication fetches from `/sync/notification/pull`.
+- No push endpoint called (verify `enablePush: false`).
+
+### E2E journey semantics
+- **New journey:** "User sees notification after household member adds item" — two authenticated sessions, one adds an item, the other syncs and has a notification record in local RxDB.
+- **Existing journeys:** Unaffected — notification creation is additive, doesn't change existing mutation behavior or sync protocol.
+
+### Manual/UAT
+- Two browser sessions (different users, same household). User A adds an item. User B's client syncs and has a notification record (verify via RxDB devtools or API). This is the data-layer validation; visual bell comes in #11b.
+
+## Documentation Impact Guess
+
+| Document | Update needed? | What |
+|----------|---------------|------|
+| `wiki/technical-design/rxdb-sync-protocol.md` | Yes | Add 'notification' to collection list (7 collections), note it's pull-only, personal (userId-filtered). Update all ~15 "six collections" references to "seven". |
+| `planning/tickets/PROJECT-STATUS.md` | Yes | Mark #11a as in-progress / completed |
+| `wiki/rules/rxdb.md` | Yes | Update "6 collections" to "7 collections" in 3 places (lines 11, 71, 78) |
+| New ADR | No | No architectural decision needed — follows existing patterns |
+| New technical design | Maybe | If notification creation pattern needs codification (dual-service: SseSyncBroadcastService for sync SSE, UserNotificationService for persisted notifications) |
+
+## Risks / Open Questions
+
+1. **Actor name lookup adds a DB query per notification creation.** Resolved: fold actor name into the household member query (one query, not two). The household fetch already includes `users.name`, so the actor is found in the result array.
+
+2. **`createMany` for N members is one query, not N.** Prisma `createMany` is a single INSERT — efficient for small households (2-5 members).
+
+3. **`RXDB_NAME` bump causes full re-sync.** All existing clients will re-pull all collections on first load after upgrade. This is the same as previous bumps and is acceptable. The sync protocol handles this gracefully (checkpoint reset → full pull).
+
+4. **Notification volume.** Every store/section/list/invitation mutation creates notifications. For a household of 4, that's 3 records per mutation. Over time, this grows. Mitigation: soft-delete + tombstone window handles cleanup. Future: add a cleanup job or TTL. Not in scope for MVP.
+
+5. **Resolved: `UserNotificationService` placement.** Lives in `SharedModule` (global), not `NotificationsModule`. Same pattern as `SseSyncBroadcastService`. `NotificationsModule` only contains the REST API.
+
+6. **Resolved: Notification creation is fire-and-forget.** Same as existing SSE notifications. If notification creation fails, the mutation still succeeded. The notification is a nice-to-have, not a consistency requirement.
+
+7. **Household deletion cascade doesn't soft-delete notifications.** `cascadeSoftDeleteHousehold` soft-deletes Store→Section→Item→List→ListItem→Household but not Notification. Orphaned notifications remain queryable by `userId` for up to 30 days (tombstone window). Probably fine — members see notifications about a now-deleted household. Acknowledged, not blocking.
+
+8. **`SseBroadcastService` is provided in both `SharedModule` and `SyncModule`.** Pre-existing duplicate. Not introduced by this plan. `UserNotificationService` in `SharedModule` gets the global instance. Worth cleaning up as a follow-up.
+
+## Implementation Notes
+
+(To be filled during implementation)
+
+## Deviations from Plan
+
+(To be filled during implementation)
+
+## Gotchas / Rationale
+
+(To be filled during implementation)
+
+## Follow-Ups
+
+- GROCERUN-33 (#11b): Notification bell UI + dual-dispatch React hooks
+- Notification preferences (opt-out per type) — future
+- Push notifications (service worker) — future, significant scope
+- Notification cleanup/TTL policy — future
+- Activity feed UI (full feed view, not just bell) — future, part of #11 epic
+- Collection consolidation: fold sections into stores (see `planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md`) — separate refactor ticket
+- Clean up `SseBroadcastService` duplicate provider in `SharedModule` + `SyncModule` — pre-existing smell
+- Update `wiki/technical-design/rxdb-sync-protocol.md` to fix misleading SSE routing claim (doc says collection-scoped, code didn't implement it — now fixed in Phase 0)

--- a/planning/tickets/notification-data-model.md
+++ b/planning/tickets/notification-data-model.md
@@ -8,7 +8,7 @@
 
 ## Background
 
-The household activity feed epic (#11) needs a data foundation: persisted user-facing notifications that sync to client devices. Currently, the only notification mechanism is a fire-and-forget SSE broadcast (`NotificationService`) that tells clients to re-pull sync collections — there are no persisted notification records, no notification API, and no notification sync collection.
+The household activity feed epic (#11) needs a data foundation: persisted user-facing notifications that sync to client devices. Currently, the only notification mechanism is the fire-and-forget SSE helper (`SseSyncBroadcastService`) that tells clients to re-pull sync collections — there are no persisted notification records, no notification API, and no notification sync collection.
 
 This ticket creates the full server-side data pipeline: Prisma model, REST API, sync integration, and notification creation in existing mutation services. #11b will build the client-side bell UI and React hooks on top of this.
 
@@ -27,24 +27,24 @@ A household member performs an action (adds an item, completes a list, joins the
 4. **Sync pull collection works** — `GET /sync/notification/pull` returns notifications for the current user, checkpoint-paginated, respecting the tombstone window.
 5. **RxDB notification collection exists** — schema, doc type, pull-only replication wired in `database.ts`, `RXDB_NAME` bumped.
 6. **SSE routing is collection-scoped** — `sharedPullStreams` changed from `Set<Subject>` to `Map<string, Subject>`, `SYNC_CHANGED` events parsed for `collections` array, RESYNC only emitted to matching streams. (Prerequisite for efficient notification dispatch.)
-7. **Self-notify skipped on push** — pusher's userId excluded from `SseBroadcastService.notifyChanged` so optimistic local writes don't trigger redundant re-pulls.
+7. **Push convergence is collection-scoped** — accepted pushes notify every affected household connection, including the pusher's other tabs/devices, so canonical server-side state converges without re-pulling unrelated collections.
 8. **Access queries memoized** — `getAccessibleStoreIdsForSync`/`getAccessibleHouseholdIdsForSync` cached per-request so 5 collections don't each make the same Prisma query.
 9. **Notifications are created on key mutations** (staged — prove pattern first, then expand):
    - Stage 1 (prove pattern): Store added
    - Stage 2 (expand): Section added, List created, List completed, Invitation accepted (member joined)
 10. **SSE dispatch** — notification creation triggers `SYNC_CHANGED` with `['notification']` collection so connected clients re-pull.
-11. **Existing `NotificationService` renamed** — SSE sync broadcast helper renamed to `SseSyncBroadcastService` to disambiguate from `UserNotificationService`. New `UserNotificationService` handles user-facing notifications.
+11. **Existing SSE helper is named `SseSyncBroadcastService`** — the user-facing `UserNotificationService` remains distinct and handles persisted notifications.
 12. **All tests pass** — unit, server integration, web component. No regressions in existing tests.
 
 ## Scope
 
 ### In scope
-- **SSE transport fixes** (prerequisite): collection-scoped SSE routing, skip self-notify on push, memoize access queries
+- **SSE transport fixes** (prerequisite, complete): collection-scoped SSE routing with canonical-name validation, full same-user fan-out, and operation-local access memoization
 - Prisma `Notification` model + migration (touches 3 models: Notification, User, Household)
 - Shared Zod DTOs for notifications
 - NestJS `NotificationsModule`: controller (REST read/mark-read) + `NotificationsService`
 - `UserNotificationService` in `SharedModule` (global): creates notification records + dispatches SSE
-- Rename existing `NotificationService` → `SseSyncBroadcastService`
+- Use the existing `SseSyncBroadcastService` name for sync-only broadcast concerns
 - Sync integration: `'notification'` pull-only collection
 - RxDB notification schema + pull replication wiring
 - Notification creation calls (staged): prove with 1 service, expand to 4 total
@@ -83,8 +83,8 @@ A household member performs an action (adds an item, completes a list, joins the
 | Server migration | `apps/server/prisma/migrations/` | New migration |
 | Server notifications | `apps/server/src/notifications/` (new) | New module (REST API only) |
 | Server sync | `apps/server/src/sync/sync.service.ts`, `apps/server/src/sync/collections/notification-sync.ts` (new) | Additive + push() exhaustiveness |
-| Server shared | `apps/server/src/shared/shared.module.ts`, `apps/server/src/shared/notification.service.ts` | Rename + export new service |
-| Server SSE | `apps/server/src/sync/sse-broadcast.service.ts` | Skip self-notify on push |
+| Server shared | `apps/server/src/shared/shared.module.ts`, `apps/server/src/shared/sse-sync-broadcast.service.ts` | Export new `UserNotificationService`; retain existing SSE helper |
+| Server SSE | `apps/server/src/sync/sse-broadcast.service.ts` | Reuse collection-scoped all-connection fan-out for notification dispatch |
 | Server services | `stores.service.ts`, `sections.service.ts`, `lists.service.ts`, `invitations.service.ts` | Additive (new call after mutations) |
 | Shared DTOs | `apps/_shared/dtos/src/index.ts` | Additive |
 | Web RxDB | `apps/web/src/core/rxdb/schema.ts`, `apps/web/src/core/rxdb/database.ts` | Additive + RXDB_NAME bump + SSE routing fix |
@@ -100,20 +100,18 @@ A household member performs an action (adds an item, completes a list, joins the
     - Update `registerPullStream` to accept collection name + subject
     - ~50 lines
 
-0b. **Skip self-notify on push** (`apps/server/src/sync/sse-broadcast.service.ts`, `apps/server/src/sync/sync.service.ts`):
-    - Thread pusher's `userId` to `SseBroadcastService.notifyChanged`
-    - Exclude pusher from the SSE recipient list (their local state is already correct from optimistic write)
-    - ~10 lines
+0b. **Preserve push convergence** (`apps/server/src/sync/sse-broadcast.service.ts`, `apps/server/src/sync/sync.controller.ts`):
+    - Keep the implemented all-connection fan-out, including the pusher's other tabs/devices
+    - Keep `SYNC_CHANGED.collections` scoped so only the changed collection pulls
 
 0c. **Memoize access queries** (`apps/server/src/sync/sync.service.ts`):
     - Cache `getAccessibleStoreIdsForSync` / `getAccessibleHouseholdIdsForSync` per-request (or 5-second TTL)
     - Eliminates 5 redundant Prisma queries during `resyncAll()`
     - ~15 lines
 
-0d. **Rename `NotificationService` → `SseSyncBroadcastService`** (`apps/server/src/shared/`):
-    - Rename file, class, and all 6 import sites (items, lists, stores, sections, households, invitations services)
-    - Prevents permanent confusion with `UserNotificationService`
-    - ~9 files touched, mechanical rename
+0d. **Use existing `SseSyncBroadcastService`** (`apps/server/src/shared/`):
+    - The rename is already complete; do not repeat it
+    - Add only the distinct `UserNotificationService` for persisted user-facing notifications
 
 ### Phase 1: Data Model + DTOs
 
@@ -228,6 +226,8 @@ type        String
         entityId: n.entityId,
         message: n.message,
         readAt: n.readAt?.toISOString() ?? null,
+        category: n.category ?? null,
+        dismissedAt: n.dismissedAt?.toISOString() ?? null,
       };
     }
 
@@ -269,6 +269,8 @@ buildBaseFilter: async (d, u) => {
       entityId: string | null;
       message: string;
       readAt: string | null;
+      category: string | null;
+      dismissedAt: string | null;
     }
 
     export const notificationSchema: RxJsonSchema<NotificationDocType> = {
@@ -287,6 +289,8 @@ buildBaseFilter: async (d, u) => {
         entityId: { type: ['string', 'null'], maxLength: 30 },
         message: { type: 'string' },
         readAt: { type: ['string', 'null'], format: 'date-time' },
+        category: { type: ['string', 'null'] },
+        dismissedAt: { type: ['string', 'null'], format: 'date-time' },
       },
       required: ['id', 'updatedAt', 'householdId', 'userId', 'type', 'actorId', 'actorName', 'entityType', 'message'],
       indexes: ['updatedAt'],
@@ -301,7 +305,7 @@ buildBaseFilter: async (d, u) => {
     - Add `export function resyncNotification()` — emits into pull stream
     - Add `function startNotificationReplication(collection)` — calls `startPullReplication({ collection, basePath: '/api/v1/sync/notification', replicationIdentifier: 'grocerun-notification-sync-v1', pullStream$: notificationPullStream$, enablePush: false })`
     - Call `startNotificationReplication(notificationCollection)` in `initDb()`
-    - Register pull stream via `registerPullStream(notificationPullStream$)`
+    - Register pull stream via `registerPullStream('notification', notificationPullStream$)` after adding `notification` to the canonical sync collection name list
 
 ### Phase 5: Notification Creation in Existing Services (Staged)
 
@@ -359,18 +363,18 @@ buildBaseFilter: async (d, u) => {
 ### Unit tests
 - **`UserNotificationService`** — `createForHousehold()`: creates N records for N-1 members (excludes actor), dispatches SSE with correct recipient IDs, handles missing household/user gracefully, fire-and-forget error handling.
 - **`NotificationsService`** — `list()`: correct Prisma query, pagination. `markRead()`: ownership check, sets `readAt`. `markAllRead()`: updates only current user's unread.
-- **`notificationToSyncDoc()`** — Correct field mapping, ISO-8601 conversion, null handling for `entityId` and `readAt`.
+- **`notificationToSyncDoc()`** — Correct field mapping, ISO-8601 conversion, null handling for `entityId`, `readAt`, `category`, and `dismissedAt`.
 
 ### Server integration tests
 - `GET /notifications` — returns only current user's notifications, sorted newest-first, respects pagination.
-- `PATCH /notifications/:id/read` — marks as read, 403 if not owner.
-- `PATCH /notifications/read-all` — marks all unread as read.
+- `PATCH /notifications/:id/read` — marks as read, 403 if not owner, and broadcasts `SYNC_CHANGED` with `['notification']` to the notification owner's connected devices.
+- `PATCH /notifications/read-all` — marks all unread as read and broadcasts `SYNC_CHANGED` with `['notification']` when rows changed.
 - `GET /sync/notification/pull` — returns notifications for current user, checkpoint pagination works, tombstone window respected.
 - **Tombstone delivery test** — create notification, soft-delete it, pull, verify `_deleted: true` in result. (Would catch the `deleted: false` in buildBaseFilter bug.)
 - After `POST /stores` (create store), a notification record exists in DB for all household members except the actor.
 - After mutation, SSE event includes `['notification']` in collections array.
 - **SSE routing test** — `SYNC_CHANGED` with `['notification']` only triggers notification pull, not other collections.
-- **Self-notify skip test** — push mutation does not send SSE to the pusher.
+- **Same-user convergence test** — a notification read on one device dispatches `['notification']` so another connected device for the same user re-pulls.
 
 ### Web component tests
 - Notification RxDB collection creates and validates documents against schema.
@@ -410,7 +414,7 @@ buildBaseFilter: async (d, u) => {
 
 7. **Household deletion cascade doesn't soft-delete notifications.** `cascadeSoftDeleteHousehold` soft-deletes Store→Section→Item→List→ListItem→Household but not Notification. Orphaned notifications remain queryable by `userId` for up to 30 days (tombstone window). Probably fine — members see notifications about a now-deleted household. Acknowledged, not blocking.
 
-8. **`SseBroadcastService` is provided in both `SharedModule` and `SyncModule`.** Pre-existing duplicate. Not introduced by this plan. `UserNotificationService` in `SharedModule` gets the global instance. Worth cleaning up as a follow-up.
+8. **Resolved: `SseBroadcastService` has one global provider.** The duplicate `SyncModule` provider was removed; `UserNotificationService` will use the shared application-wide connection registry.
 
 ## Implementation Notes
 
@@ -432,5 +436,4 @@ buildBaseFilter: async (d, u) => {
 - Notification cleanup/TTL policy — future
 - Activity feed UI (full feed view, not just bell) — future, part of #11 epic
 - Collection consolidation: fold sections into stores (see `planning/brainstorm/2026-07-10T0000_sse-sync-split-analysis.md`) — separate refactor ticket
-- Clean up `SseBroadcastService` duplicate provider in `SharedModule` + `SyncModule` — pre-existing smell
-- Update `wiki/technical-design/rxdb-sync-protocol.md` to fix misleading SSE routing claim (doc says collection-scoped, code didn't implement it — now fixed in Phase 0)
+- Update `wiki/technical-design/rxdb-sync-protocol.md` when the notification collection is implemented to add it to the collection inventory

--- a/wiki/technical-design/sse-resync-broadcast.md
+++ b/wiki/technical-design/sse-resync-broadcast.md
@@ -2,604 +2,112 @@
 
 ## Purpose
 
-The SSE (Server-Sent Events) resync broadcast system bridges server-side mutations — both
-push-triggered and REST-triggered — to real-time client notification via a single shared
-`EventSource` connection per browser session.
+The SSE resync broadcast protocol tells connected browsers which RxDB collections must pull canonical server state after a mutation. It covers both local-first sync pushes and server-authoritative REST mutations.
 
-It solves three problems:
+The protocol prioritizes convergence over avoiding a redundant pull. A client that writes a change still receives the corresponding `SYNC_CHANGED` event because the server can add or restore canonical fields that are absent from the push response. All connections for that user, including other tabs and devices, receive the event.
 
-1. **REST mutations happen server-side only.** Collection-authoritative writes (section,
-   store, list, household) run through REST endpoints. The client has no local write to
-   push. SSE signals the client to re-pull the affected collections.
+## Ownership and Scope
 
-2. **Push mutations affect multiple users.** When one user pushes a changed `item` or
-   `listItem`, other household members must learn about it without polling. SSE fans out
-   the `SYNC_CHANGED` event to all connected members.
+- `SseBroadcastService` is the single, app-wide connection registry. It is provided by global `SharedModule`; feature modules and `SyncModule` consume that provider and must not register another provider instance.
+- `SseSyncBroadcastService` resolves a store or household to member user IDs, then delegates to `SseBroadcastService`.
+- `SyncController` registers the browser's stream connection and broadcasts accepted sync pushes.
+- `database.ts` owns one `EventSource` per browser session and routes events to the registered RxDB pull streams.
+- The connection registry is in-memory and process-local. A multi-process deployment needs a shared pub/sub transport such as Redis.
 
-3. **Household membership changes require client-side cascade.** When a user is removed
-   from a household, the client must delete the entire household subtree from IndexedDB.
-   SSE delivers the `HOUSEHOLD_REMOVED` event with the `householdId`.
+## Event Contract
 
-The broadcast service is an **in-memory, single-process** fan-out (`Map<string, Set<Response>>`).
-It carries no persistence and does not retry failed writes. Clients that disconnect miss
-intermediate events and catch up on reconnect via a full pull (triggered by the initial
-`RESYNC` event).
+| Event | Server payload | Client action |
+|---|---|---|
+| `RESYNC` | `{}` | Pull every registered collection. Sent immediately after connecting. |
+| `SYNC_CHANGED` | `{ collections: SyncCollection[], reason: string }` | Pull only the named collections. Malformed, empty, or missing `collections` falls back to every collection. |
+| `HEARTBEAT` | `{}` | Reset the SSE inactivity watchdog. No pull. Sent every 15 seconds. |
+| `HOUSEHOLD_REMOVED` | `{ householdId: string }` | Remove that household and its subtree from local RxDB. |
 
-**Files:**
-- `apps/server/src/sync/sse-broadcast.service.ts` — 61-line broadcast service
-- `apps/server/src/sync/sync.controller.ts:97-141` — SSE endpoint (`openStream`)
-- `apps/web/src/core/rxdb/database.ts:523-581` — Client `EventSource` consumption
+`EventSource` does not surface SSE comment frames to application code. The server therefore sends a named `HEARTBEAT` event instead of `: heartbeat` comments. The client watchdog is 20 seconds; a healthy 15-second heartbeat prevents false reconnects and the full `RESYNC` pulls they would otherwise cause.
 
-## Scope and Non-Goals
-
-### In scope
-
-- In-memory `Map<userId, Set<Response>>` connection registry — register, broadcast,
-  unregister, unregisterAll.
-- Three SSE event types: `RESYNC` (initial connect), `SYNC_CHANGED` (data mutation),
-  `HOUSEHOLD_REMOVED` (household membership change).
-- Single SSE endpoint (`GET /sync/stream`) consumed by one shared `EventSource` per
-  browser session.
-- Heartbeat mechanism (25-second interval) to keep connections alive through proxies
-  and load balancers.
-- Token-as-query-param auth for SSE (`?token=...`) — the only endpoint that accepts
-  query-token auth because `EventSource` cannot set custom headers.
-- Fire-and-forget broadcast: writes to SSE `Response` are not retried on failure.
-- Cleanup on connection close: auto-removes `Response` from the user's Set; deletes
-  the userId entry when the Set empties.
-- Notification routing from REST services via `NotificationService` (`notify.byStore()`,
-  `notify.byHousehold()`) which resolves to `SseBroadcastService.notifyChanged()`.
-
-### Out of scope / non-goals
-
-- **Cross-process broadcast**: No Redis pub/sub or message queue. The service comment
-  explicitly says "for multi-process deployments, replace with Redis pub/sub."
-- **Message persistence / replay**: If a client is disconnected it misses events. Catch-up
-  happens via the initial `RESYNC` on reconnect, which triggers a full re-pull.
-- **Per-collection SSE endpoints**: A single `/sync/stream` feeds all six collections.
-  The `SYNC_CHANGED` event carries a `collections` array to scope the re-pull.
-- **Retry logic**: SSE writes that fail (e.g., client disconnected mid-write) are silently
-  dropped. No write queue or retry scheduler.
-- **Backpressure**: The service does not monitor TCP buffer capacity. If the client is
-  slow to consume, data may accumulate in kernel buffers.
-- **Multi-tab coordination**: Each browser tab opens its own `EventSource`. There is no
-  `BroadcastChannel` or `SharedWorker` to deduplicate across tabs.
-- **Heartbeat monitoring on client**: The client has no heartbeat timeout. Heartbeat is
-  purely server-side keepalive for proxies/load balancers.
-
-## Connection Model
-
-### SSE connection lifecycle
-
-```mermaid
-stateDiagram-v2
-    [*] --> Registering : GET /sync/stream?token=...
-    Registering --> Active : sseBroadcast.register(userId, res)
-    Registering --> Rejected : Auth guard rejects token
-    Rejected --> [*] : 401 response
-
-    Active --> Heartbeat : 25s interval
-    Heartbeat --> Active : send ': heartbeat\n\n'
-
-    Active --> Broadcasting : mutation occurs
-    Broadcasting --> Active : notifyChanged() / notifyHouseholdRemoved()
-
-    Active --> Closing : res.on('close')
-    Closing --> [*] : sseBroadcast unregister<br/>clear heartbeat interval
-
-    Active --> Error : write error / network failure
-    Error --> [*] : client disconnect
-```
-
-### Multiple connections per user
-
-```mermaid
-graph TB
-    subgraph Server["NestJS Server"]
-        SSE["SseBroadcastService"]
-    end
-
-    subgraph Tab1["Browser Tab 1"]
-        ES1["EventSource 1"]
-        DB1["IndexedDB (RxDB)"]
-    end
-
-    subgraph Tab2["Browser Tab 2"]
-        ES2["EventSource 2"]
-        DB2["IndexedDB (RxDB)"]
-    end
-
-    Tab1 -->|"userId: abc123"| SSE
-    Tab2 -->|"userId: abc123"| SSE
-
-    SSE -->|"SYNC_CHANGED<br/>broadcast"| ES1
-    SSE -->|"SYNC_CHANGED<br/>broadcast"| ES2
-```
-
-One `userId` maps to a `Set<Response>`. Each tab registers its own `Response`. When a
-broadcast occurs, the service iterates the entire Set and writes to every response.
-Cleanup is per-connection: when one tab closes, only that `Response` is removed from
-the Set. The userId entry persists as long as at least one connection remains.
-
-### Connection registry state
-
-| State | Condition | Behaviour |
-|-------|-----------|-----------|
-| **Empty** | `connections` map has no entry for userId | Broadcast is a no-op for that user |
-| **Active (1 connection)** | `Set` has size 1 | Broadcast writes to one `Response` |
-| **Active (N connections)** | `Set` has size > 1 | Broadcast writes to all N `Response` objects |
-| **Draining** | Connection `close` event fired | Remove `Response` from Set; if Set empties, delete userId entry |
-
-## Call Sequence
-
-### Connection registration and initial RESYNC
+## Connection Lifecycle
 
 ```mermaid
 sequenceDiagram
-    participant Client as Web Client (EventSource)
-    participant Ctrl as sync.controller.ts<br/>(openStream)
-    participant Guard as auth.guard.ts
-    participant Broadcast as SseBroadcastService
+    participant C as "Web client"
+    participant A as "Auth guard"
+    participant S as "Sync controller"
+    participant B as "SSE broadcast service"
 
-    Client->>Guard: GET /api/v1/sync/stream?token=JWT
-    Note over Client, Guard: EventSource connects<br/>token in query param (no custom headers)
-
-    Guard->>Guard: decode JWT from req.query.token
-    Guard-->>Ctrl: userId available on request
-
-    Ctrl->>Ctrl: set SSE headers<br/>Content-Type: text/event-stream<br/>Cache-Control: no-cache<br/>Connection: keep-alive<br/>X-Accel-Buffering: no
-
-    Ctrl-->>Client: event: RESYNC\n{}\n\n
-    Note over Client: Client emits 'RESYNC'<br/>to all 6 pull Subjects
-
-    Ctrl->>Broadcast: register(userId, res)
-    Broadcast-->>Ctrl: unregister() function
-
-    par Heartbeat loop
-        loop every 25 seconds
-            Ctrl-->>Client: : heartbeat\n\n
-        end
-    end
-
-    Note over Client: On connection close:
-    Client->>Ctrl: res.on('close')
-    Ctrl->>Broadcast: unregister() → removes res from Set
-    Ctrl->>Ctrl: clearInterval(heartbeat)
+    C->>A: "GET /sync/stream?token=JWT"
+    A->>S: "authenticated userId"
+    S->>C: "RESYNC event"
+    S->>B: "register user connection"
+    S->>C: "HEARTBEAT event every 15 seconds"
+    B->>C: "SYNC_CHANGED for every matching connection"
+    C->>C: "route event to affected RxDB pull streams"
+    C->>S: "incremental collection pull"
 ```
 
-### Broadcast after push mutation
+`register(userId, response)` stores a response in `Map<userId, Set<Response>>` and returns a cleanup callback. The controller calls the callback and clears the heartbeat interval when the HTTP response closes. A user can have any number of connections; a broadcast writes to each response in that user's set.
 
-```mermaid
-sequenceDiagram
-    participant Pusher as Pushing Client
-    participant Ctrl as sync.controller.ts<br/>(push endpoint)
-    participant Svc as sync.service.ts
-    participant Handler as Collection Push Handler
-    participant Broadcast as SseBroadcastService
-    participant Other as Other Household Members<br/>(SSE connected)
+## Broadcast Semantics
 
-    Pusher->>Ctrl: POST /sync/:collection/push
-    Ctrl->>Svc: push(collection, rows, userId)
-    Svc->>Handler: pushItems/pushListItems(rows, userId)
+### Sync pushes
 
-    Handler->>Handler: process rows (upsert / conflict)
-    Handler-->>Svc: result
+After an accepted `item` or `listItem` push, `SyncController` resolves the affected household members and broadcasts:
 
-    Svc->>Svc: syncService.getHouseholdMemberIds(collection, rows)
-    Note over Svc: Resolves all user IDs<br/>who should see this change
-
-    alt members found
-        Svc->>Broadcast: notifyChanged(memberIds, { collections: ['listItem'], reason: 'listItem.push' })
-    else no members found
-        Svc->>Broadcast: notifyChanged([pusherId], { collections: ['listItem'], reason: 'listItem.push' })
-    end
-
-    Broadcast->>Broadcast: iterate connections map for each memberId
-    Broadcast-->>Other: event: SYNC_CHANGED\n{ collections: ['listItem'], reason: 'listItem.push' }
-    Broadcast-->>Pusher: event: SYNC_CHANGED\n(if pusher is also a member)
-
-    Other->>Other: emit 'RESYNC' to affected collection pull Subjects
-    Pusher->>Pusher: (receives SYNC_CHANGED but<br/>already has latest state)
+```text
+SYNC_CHANGED { collections: [pushedCollection], reason: "<collection>.push" }
 ```
 
-### Broadcast after REST mutation
+The pusher is included. This is deliberate:
 
-```mermaid
-sequenceDiagram
-    participant REST as REST Service<br/>(e.g., stores.service.ts)
-    participant Notify as NotificationService
-    participant Broadcast as SseBroadcastService
-    participant Client as SSE-connected Clients
+- another tab or device for the same user must converge;
+- server-generated fields, restore-on-create behavior, and canonical conflict results can require a pull even for the originating client;
+- collection scoping confines this reconciliation to one pull stream rather than forcing every collection to pull.
 
-    REST->>REST: perform mutation (e.g., PATCH /stores/:storeId)
-    REST->>Notify: this.notify.byStore(storeId, ['list', 'listItem'], 'list-mutation')
-    Note over Notify: byStore resolves storeId → member userIds<br/>byHousehold resolves householdId → member userIds
+### REST mutations and manifests
 
-    Notify->>Broadcast: notifyChanged(userIds, { collections: ['list', 'listItem'], reason: 'list-mutation' })
+`apps/server/src/shared/sync-change.ts` defines the typed `SYNC_CHANGE` manifests. A manifest is a correctness contract: it lists every replicated document type the operation can mutate directly or indirectly. Services must use these constants instead of inline arrays.
 
-    Broadcast->>Broadcast: for each userId, iterate Set<Response>
-    loop for each connected Response
-        Broadcast-->>Client: event: SYNC_CHANGED\n{ collections: ['list', 'listItem'], reason: 'list-mutation' }
-    end
+| Operation class | Manifest |
+|---|---|
+| Store create or update | `store` |
+| Store soft-delete cascade | `store`, `section`, `item`, `list`, `listItem` |
+| Section create, update, or reorder | `section` |
+| Section delete with item reassignment | `section`, `item` |
+| Catalog item update | `item` |
+| List create, start shopping, or cancel shopping | `list` |
+| List-item add or restore, including catalog-item creation or update | `item`, `listItem` |
+| List-item toggle, quantity update, or soft-delete | `listItem` |
+| List completion with catalog purchase-stat updates | `list`, `item`, `listItem` |
+| Household create, rename, leave, or member removal | `household` |
+| Household soft-delete cascade or invitation join | all replicated collections |
 
-    Client->>Client: emit 'RESYNC' to 'list' and 'listItem' pull Subjects
-    Client->>Client: RxDB re-pulls those collections
-```
+The local REST mutation hooks issue the same immediate resyncs for cascade and side-effect operations. SSE remains the source of remote-client convergence and the recovery path for a missed local resync.
 
-### Household removal broadcast
+## Failure and Recovery Model
 
-```mermaid
-sequenceDiagram
-    participant REST as households.service.ts
-    participant Broadcast as SseBroadcastService
-    participant RemovedUser as Removed User's Client
-    participant OtherMembers as Other Household Members
+- Broadcast writes are fire-and-forget and are not retried. A disconnected client catches up from its initial `RESYNC` after reconnecting.
+- `EventSource` errors close the source, start the 5-second periodic pull fallback, and schedule a reconnect.
+- When the source opens, periodic fallback polling stops.
+- When the tab becomes hidden, the client closes the source and starts fallback polling. When visible again, it performs an all-collection resync and reopens the source.
+- The client treats malformed `SYNC_CHANGED` payloads as a safe all-collection resync rather than silently leaving data stale.
 
-    REST->>REST: cascadeSoftDeleteHousehold(tx, householdId, now)
-    REST->>Broadcast: notifyHouseholdRemoved([userId], householdId)
-    Note over REST: userId = the user being removed
+## Sync Access Query Memoization
 
-    Broadcast-->>RemovedUser: event: HOUSEHOLD_REMOVED\n{ householdId }
+`SyncService` is a singleton. Each `pull()` or `push()` therefore creates a fresh dependency object with an operation-local cache for accessible store and household IDs. Calls repeated within that one operation share a promise; concurrent operations do not clear, reuse, or evict one another's cache entries.
 
-    RemovedUser->>RemovedUser: removeHouseholdSubtreeFromLocalDb(householdId)
-    Note over RemovedUser: 1. find stores in household<br/>2. cascade delete sections, items, lists, listItems<br/>3. delete household itself
+## Security
 
-    Note over OtherMembers: Other members still see the household.<br/>They receive a subsequent SYNC_CHANGED<br/>via the REST mutation notification.
-```
+The standard API uses bearer authorization. The SSE endpoint additionally accepts a JWT query parameter because browser `EventSource` cannot attach custom headers. Query-token handling is restricted to the sync stream fallback in `AuthGuard`; it must not be extended to other endpoints.
 
-## Layer Boundaries
+## Tests
 
-```mermaid
-graph TB
-    subgraph Client["Web Client (browser)"]
-        subgraph SSE_Client["SSE Layer"]
-            ES["EventSource<br/>/api/v1/sync/stream<br/>?token=..."]
-            SSE_Handler["database.ts:537-581<br/>onopen / onerror / onmessage"]
-            PullSubjects["6 per-collection<br/>Rx.Subject<'RESYNC'>"]
-        end
+- `apps/server/test/sync/sse-broadcast.spec.ts` verifies fan-out to every household member and every same-user connection.
+- `apps/server/test/sync/sse-notify.spec.ts` verifies push delivery to the pusher and REST manifests for store cascades, section reassignment, list-item catalog effects, and list completion effects.
+- `apps/server/test/sync/sync.service.spec.ts` verifies within-operation memoization and independent overlapping operation caches.
+- `apps/web/src/core/rxdb/__tests__/sync-stream.test.ts` verifies collection routing, defensive fallback routing, registration replacement semantics, and heartbeat watchdog behavior with fake timers.
 
-        subgraph RxDB["RxDB Layer"]
-            Pull["pull.handler × 6<br/>GET /sync/:collection/pull"]
-            DB["IndexedDB (Dexie)"]
-        end
+## Non-Goals
 
-        ES --> SSE_Handler
-        SSE_Handler -->|"RESYNC / SYNC_CHANGED"| PullSubjects
-        SSE_Handler -->|"HOUSEHOLD_REMOVED"| DB
-        PullSubjects --> Pull
-    end
-
-    subgraph Server["NestJS Server"]
-        subgraph Transport["Transport"]
-            HTTP["HTTP pull/push"]
-            SSE_EP["GET /sync/stream<br/>(SSE endpoint)"]
-            Guard["auth.guard.ts<br/>(query-token fallback)"]
-        end
-
-        subgraph Broadcast["Broadcast Layer"]
-            SSE_Svc["sse-broadcast.service.ts<br/>Map<userId, Set<Response>>"]
-        end
-
-        subgraph Controllers["Controllers"]
-            SyncCtrl["sync.controller.ts<br/>openStream()"]
-        end
-
-        subgraph Services["Services"]
-            SyncSvc["sync.service.ts<br/>getHouseholdMemberIds()"]
-            Notification["NotificationService<br/>byStore(), byHousehold()"]
-        end
-
-        subgraph REST["REST Services"]
-            Stores["stores.service.ts"]
-            Sections["sections.service.ts"]
-            Lists["lists.service.ts"]
-            Households["households.service.ts"]
-        end
-
-        subgraph Handlers["Sync Handlers"]
-            Push["collection push handlers<br/>(item-sync, list-item-sync)"]
-        end
-
-        Guard --> SSE_EP
-        SSE_EP --> SyncCtrl
-        SyncCtrl --> SSE_Svc
-        Push -->|"notifyChanged"| SSE_Svc
-        REST --> Notification
-        Notification --> SSE_Svc
-        SSE_Svc --> SSE_EP
-    end
-
-    Client -- HTTPS --> Server
-    SSE_EP -- text/event-stream --> Client
-```
-
-### Boundary rules
-
-1. **SSE events are fire-and-forget.** The `SseBroadcastService` writes to `Response`
-   objects without awaiting or retrying. Failed writes (closed connection) are silently
-   dropped.
-
-2. **Broadcast resolution is userId-based.** REST services call `NotificationService`
-   with a `storeId` or `householdId`; the service resolves to affected `userId[]`. The
-   broadcast service does not know about stores or households — it only knows
-   `userId → Set<Response>`.
-
-3. **Push broadcasts are collection-scoped.** The push handler resolves member IDs via
-   `syncService.getHouseholdMemberIds(collection, rows)` and passes the collection name
-   in the `SYNC_CHANGED` payload. The client uses the `collections` array to emit
-   `'RESYNC'` only into affected pull Subjects.
-
-4. **REST broadcasts are reason-scoped.** Services pass a `reason` string (e.g.,
-   `'list-mutation'`, `'invitation-mutation'`) for observability. The client currently
-   treats all `SYNC_CHANGED` events identically (emits `'RESYNC'` to all Subjects), but
-   the payload schema supports collection-scoped re-pull in the future.
-
-5. **The SSE endpoint is the only query-token auth user.** The auth guard checks
-   `req.query.token` only as a fallback when no `Authorization` header is present.
-   This is because `EventSource` cannot set custom headers. No other endpoint accepts
-   query-token auth.
-
-6. **Cleanup is event-driven per-connection.** The `unregister()` function returned by
-   `register()` is called in the SSE response's `close` event. This ensures cleanup
-   happens even if the process restarts (the connection dies, firing the event).
-
-7. **No cross-process isolation.** The in-memory `Map` is process-local. In a multi-process
-   deployment (e.g., multiple Node.js instances behind a load balancer), SSE connections
-   for the same user could land on different processes and never see each other's broadcasts.
-   The service comment explicitly flags this as a Redis pub/sub replacement point.
-
-## Key Types and Objects
-
-### `SseBroadcastService` (`apps/server/src/sync/sse-broadcast.service.ts`)
-
-```typescript
-@Injectable()
-class SseBroadcastService {
-  private connections: Map<string, Set<Response>>;
-
-  /**
-   * Register an SSE Response for a userId.
-   * Returns an unregister function for cleanup.
-   */
-  register(userId: string, res: Response): () => void;
-  // 1. Gets or creates Set<Response> for userId
-  // 2. Adds res to Set
-  // 3. Returns () => {
-  //      res.end();
-  //      connections.get(userId)?.delete(res);
-  //      if (Set empties) connections.delete(userId);
-  //    }
-
-  /**
-   * Broadcast SYNC_CHANGED event to all connections for the given userIds.
-   */
-  notifyChanged(
-    userIds: string[],
-    payload: { collections: string[]; reason: string },
-  ): void;
-  // 1. For each userId in userIds:
-  //    - Get Set<Response> from connections map
-  //    - For each Response: res.write(`event: SYNC_CHANGED\n`)
-  //    - Silently skip if write fails or Response is destroyed
-
-  /**
-   * Broadcast HOUSEHOLD_REMOVED event to all connections for the given userIds.
-   */
-  notifyHouseholdRemoved(userIds: string[], householdId: string): void;
-  // 1. For each userId in userIds:
-  //    - Same pattern as notifyChanged
-  //    - Writes: `event: HOUSEHOLD_REMOVED\ndata: { householdId }\n\n`
-
-  /**
-   * Unregister all connections for a userId (used during logout / account deletion).
-   */
-  unregisterAll(userId: string): void;
-  // 1. Get Set<Response> for userId
-  // 2. res.end() for each Response
-  // 3. Delete userId from connections map
-}
-```
-
-### SSE event types
-
-| Event | Sent When | Payload | Client Action | Source |
-|-------|-----------|---------|---------------|--------|
-| `RESYNC` | Initial connect (`sync.controller.ts:125`) | `{}` | Emit `'RESYNC'` to all 6 pull Subjects — full re-pull | `database.ts:545-550` |
-| `SYNC_CHANGED` | After push mutation (`sync.controller.ts:76-79`); after REST mutation via `NotificationService` | `{ collections: string[], reason: string }` | Emit `'RESYNC'` to all pull Subjects (currently all 6; future: collection-scoped) | `database.ts:555-565` |
-| `HOUSEHOLD_REMOVED` | When user is removed from a household | `{ householdId: string }` | `removeHouseholdSubtreeFromLocalDb(householdId)` — cascade delete from IndexedDB | `database.ts:570-575` |
-| `: heartbeat` | Every 25s via `setInterval` | (comment line — ignored by `EventSource`) | Keeps TCP connection alive through proxies/load balancers | `sync.controller.ts:130-135` |
-
-### SSE endpoint headers (`sync.controller.ts:116-120`)
-
-```typescript
-// Set by openStream() before any data is sent
-res.setHeader('Content-Type', 'text/event-stream');
-res.setHeader('Cache-Control', 'no-cache');
-res.setHeader('Connection', 'keep-alive');
-res.setHeader('X-Accel-Buffering', 'no'); // Disable Nginx buffering
-```
-
-### Notification service routing
-
-```typescript
-// apps/server/src/sync/notification.service.ts (conceptual)
-class NotificationService {
-  /**
-   * Resolve store members and broadcast.
-   * Used by REST services after store-scoped mutations.
-   */
-  byStore(
-    storeId: string,
-    collections: string[],
-    reason: string,
-  ): void;
-
-  /**
-   * Resolve household members and broadcast.
-   * Used by REST services after household-scoped mutations.
-   */
-  byHousehold(
-    householdId: string,
-    collections: string[],
-    reason: string,
-  ): void;
-}
-```
-
-### Auth guard query-token fallback (`auth.guard.ts:95-115`)
-
-```typescript
-// Only the SSE endpoint uses this path
-if (!token && req.query?.token) {
-  token = req.query.token as string;
-}
-// This is checked AFTER Authorization header is absent
-// No other endpoint should accept query-token auth
-```
-
-### Client-side EventSource setup (`database.ts:523-581`)
-
-```typescript
-// Single shared EventSource per browser session
-const url = `${API_BASE}/sync/stream?token=${encodeURIComponent(token)}`;
-const source = new EventSource(url);
-
-source.addEventListener('RESYNC', () => {
-  // Emit 'RESYNC' to all 6 pull Subjects
-  subjects.forEach(subj => subj.next('RESYNC'));
-});
-
-source.addEventListener('SYNC_CHANGED', (event) => {
-  const { collections } = JSON.parse(event.data);
-  // Currently emits to all Subjects regardless of collections
-  subjects.forEach(subj => subj.next('RESYNC'));
-});
-
-source.addEventListener('HOUSEHOLD_REMOVED', (event) => {
-  const { householdId } = JSON.parse(event.data);
-  removeHouseholdSubtreeFromLocalDb(householdId);
-});
-
-source.onopen = () => {
-  // SSE healthy → stop periodic resync fallback
-  clearInterval(periodicResyncTimer);
-};
-
-source.onerror = () => {
-  // SSE disconnected → start periodic resync, reconnect after 5s
-  source.close();
-  startPeriodicResync();
-  setTimeout(() => { source = new EventSource(url); }, 5000);
-};
-```
-
-## Failure Modes
-
-### SSE connection failures
-
-| Scenario | Detection | Behaviour | Source |
-|----------|-----------|-----------|--------|
-| Network drops | `EventSource.onerror` fires | Closes EventSource. Starts `setInterval(resyncAll, 5000)`. Reconnects after 5-second delay. | `database.ts:538-555` |
-| Token expired on connect | SSE endpoint returns 401 | `EventSource` fires `onerror`. Client reconnects after 5s with fresh token from memory. | `database.ts:538-555`; implicit reconnect |
-| Token expires mid-stream | SSE endpoint terminates connection | Same as above — `EventSource.onerror` fires, reconnect cycle begins with refreshed token. | Auto-reconnect |
-| Browser tab hidden → SSE throttled | Browser throttles EventSource events | When tab becomes visible again, `visibilitychange` listener triggers `resyncAll()` to all collections, compensating for missed events. | `database.ts:487-497` |
-| Proxy / load balancer timeout | No explicit detection; heartbeat prevents it | 25s heartbeat keeps connection alive. If heartbeat is also dropped, `EventSource.onerror` fires. | `sync.controller.ts:130-135` |
-| Nginx buffering enabled | SSE events delayed/batched | `X-Accel-Buffering: no` header disables Nginx response buffering. | `sync.controller.ts:119` |
-
-### Broadcast failures
-
-| Scenario | Detection | Behaviour | Source |
-|----------|-----------|-----------|--------|
-| Write to disconnected client | `res.write()` throws or `res.destroyed` is true | Silently skipped. No retry. The `unregister()` cleanup will eventually remove the stale Response on the `close` event. | `sse-broadcast.service.ts` (implicit) |
-| Write to slow consumer (buffer full) | Node.js internal buffer pressure | No backpressure handling. Data may be lost if the kernel buffer overflows. In practice, heartbeat and small event payloads make this unlikely. | No explicit handling |
-| Broadcast to empty userId | `connections.get(userId)` returns `undefined` | No-op. Iteration of `userIds` continues to next entry. | `sse-broadcast.service.ts` (implicit) |
-| Race: close fires mid-broadcast | `Response` removed from Set while iterating | Iteration uses `Set.forEach()` which copies references. If `close` fires during iteration, the `res.write()` on the removed response may throw — caught and silently dropped. | `sse-broadcast.service.ts` |
-
-### Multi-process / horizontal scaling failures
-
-| Scenario | Detection | Behaviour | Source |
-|----------|-----------|-----------|--------|
-| User connected to process A; mutation arrives at process B | Broadcast on process B has no connection for user | User on process A never receives the event. On next pull (periodic timer or manual resync), the user catches up. Comment: "replace with Redis pub/sub". | `sse-broadcast.service.ts` header comment |
-| Process restarts mid-session | All in-memory connections destroyed | Client `EventSource` detects dropped connection via `onerror`, reconnects to the new process, receives initial `RESYNC`, and re-pulls all collections. | `database.ts:538-555` |
-
-### Notification routing failures
-
-| Scenario | Detection | Behaviour | Source |
-|----------|-----------|-----------|--------|
-| `getHouseholdMemberIds` returns empty array | `sync.service.ts` checks length | Falls back to broadcasting to the pushing user only. | `sync.controller.ts:72-79` |
-| `NotificationService.byStore` called with invalid storeId | Prisma query returns no members | No-op broadcast (empty userId array). Mutation still succeeds. | `notification.service.ts` (implied) |
-| Wrong `collections` array in payload | Client receives `SYNC_CHANGED` for wrong collections | Currently harmless — client re-pulls all 6 collections regardless. Future collection-scoped re-pull could cause stale data if a collection is not listed. | `database.ts:560-565` |
-
-## Tests and Verification Hooks
-
-### Server-side tests
-
-| File | What it covers | Status |
-|------|---------------|--------|
-| `apps/server/test/sync/sse-broadcast.spec.ts` | SSE broadcast service: register, notifyChanged, notifyHouseholdRemoved, unregisterAll, cleanup on close | Written |
-
-### E2E tests
-
-| File | What it covers | Status |
-|------|---------------|--------|
-| `apps/e2e/tests/sync-sse.spec.ts` | SSE connection lifecycle, mutation triggers SYNC_CHANGED, client re-pulls | Written |
-| `apps/e2e/tests/sync-household-removal.spec.ts` | Household deletion cascades via SSE → client removes subtree from IndexedDB | Written |
-
-### Running the tests
-
-```bash
-# SSE broadcast unit tests
-npx vitest run apps/server/test/sync/sse-broadcast.spec.ts
-
-# All server sync tests
-npx vitest run apps/server/test/sync/
-
-# E2E SSE tests (requires `npm run dev`)
-npx playwright test apps/e2e/tests/sync-sse.spec.ts
-npx playwright test apps/e2e/tests/sync-household-removal.spec.ts
-```
-
-### Verification hooks
-
-1. **SSE event trace in console**: The client logs SSE events at `info` level in
-   `database.ts:560-565`. Set `localStorage.debug = 'grocerun:rxdb:*'` to enable verbose
-   SSE logging.
-
-2. **Connection registry inspection**: In devtools, the `SseBroadcastService` connections
-   map can be inspected via the Node.js debugger or by adding a temporary debug endpoint.
-
-3. **Heartbeat observability**: The server-side heartbeat interval writes `: heartbeat\n\n`
-   every 25s. These are visible in the Network tab of browser devtools as data frames on
-   the SSE stream.
-
-4. **Periodic resync toggle**: The `setInterval` handle for periodic fallback resync is
-   stored on `window.__grocerun_resync_timer` for manual inspection in devtools.
-
-5. **Token refresh logging**: Auth token refresh attempts are logged at `debug` level in
-   `database.ts:55-63`. If SSE reconnection fails due to token issues, the log shows the
-   refresh attempt and its outcome.
-
-## Related Docs
-
-- `apps/server/src/sync/sse-broadcast.service.ts` — In-memory SSE fan-out service (61 lines).
-- `apps/server/src/sync/sync.controller.ts` — Pull, push, and stream endpoints; `openStream()`
-  at lines 114-141 (142 lines).
-- `apps/server/src/sync/sync.service.ts` — Pull/push dispatch, `getHouseholdMemberIds()`
-  for push-triggered broadcasts (258 lines).
-- `apps/server/src/auth/auth.guard.ts` — JWT auth guard with query-token fallback for SSE
-  (lines 95-115).
-- `apps/web/src/core/rxdb/database.ts` — Client RxDB setup, EventSource connection,
-  periodic resync, `removeHouseholdSubtreeFromLocalDb()` (630 lines).
-- `apps/web/src/core/auth/session.ts` — `getAppAccessToken()` / `refreshAppAccessToken()`
-  used to obtain the SSE token query parameter.
-- [`wiki/technical-design/rxdb-sync-protocol.md`](./rxdb-sync-protocol.md) — Full RxDB
-  pull/push/stream protocol, checkpoint pagination, conflict detection, and sync model.
-- [`wiki/technical-design/soft-delete-cascade.md`](./soft-delete-cascade.md) — Soft-delete
-  lifecycle and cascade order; relevant because `HOUSEHOLD_REMOVED` triggers client-side
-  cascade delete matching the server's cascade order.
-- [`wiki/technical-design/household-invitation-lifecycle.md`](./household-invitation-lifecycle.md) —
-  Invitation flow; household removal events flow from the same lifecycle.
-- [`wiki/architecture/data-sync-and-concurrency.md`](../architecture/data-sync-and-concurrency.md) —
-  High-level sync architecture and concurrency model.
-- [EventSource MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) — Client
-  API documentation for the SSE consumer.
+- Cross-process fan-out or durable event replay.
+- Per-connection self-notify suppression. Implementing it safely requires a client connection ID and proof that the push response contains every canonical server mutation.
+- Backpressure management or retrying failed response writes.
+- An end-to-end multi-browser suite. The server integration and web stream tests cover the protocol; a manual two-tab check remains useful before a release that changes this transport.


### PR DESCRIPTION
…ccess, rename NotificationService

- SSE routing: sharedPullStreams Set→Map, parse collections array from SYNC_CHANGED events, only dispatch RESYNC to matching pull streams
- Skip self-notify: exclude pusher userId from SSE broadcast on push (local state already correct from optimistic write)
- Memoize access queries: cache getAccessibleStoreIdsForSync and getAccessibleHouseholdIdsForSync per-request, clear on each pull/push
- Rename NotificationService → SseSyncBroadcastService to disambiguate from upcoming UserNotificationService (mechanical rename, 9 files)
- Planning docs: notification data model ticket + analysis + SSE sync split brainstorm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collection-specific synchronization for household, store, section, item, list, and list-item changes.
  * Updates now refresh only affected data, with safe fallback behavior when change details are unavailable.
  * Added named SSE heartbeat events to improve connection liveness and recovery.
  * Related data now resynchronizes after completing lists or deleting sections and stores.

* **Bug Fixes**
  * Improved synchronization for cascade changes and updates across multiple connected devices.

* **Tests**
  * Added comprehensive coverage for SSE delivery, selective resyncing, heartbeats, access caching, and mutation broadcasts.

* **Documentation**
  * Updated the SSE synchronization protocol and notification implementation plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->